### PR TITLE
Fewer statics, and clear without public app

### DIFF
--- a/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheHelper.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheHelper.cs
@@ -91,11 +91,6 @@ namespace Microsoft.Identity.Client.Extensions.Msal
         }
 
         /// <summary>
-        /// Gets whether this instance has had <see cref="RegisterCache(ITokenCache)" /> called.
-        /// </summary>
-        public bool Registerred { get; private set; }
-
-        /// <summary>
         /// Gets a singleton instance of the TokenCacheHelper
         /// </summary>
         /// <param name="tokenCache">Token Cache</param>
@@ -129,7 +124,6 @@ namespace Microsoft.Identity.Client.Extensions.Msal
                     }
                 }
 
-                Registerred = true;
                 _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Done initializing");
             }
         }

--- a/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheHelper.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheHelper.cs
@@ -18,17 +18,18 @@ namespace Microsoft.Identity.Client.Extensions.Msal
         /// </summary>
         private static readonly object s_lockObject = new object();
 
+        /// <summary>
+        /// A default logger for use if the user doesn't want to provide their own.
+        /// </summary>
         private static readonly Lazy<TraceSource> s_staticLogger = new Lazy<TraceSource>(() =>
         {
             return (TraceSource)EnvUtils.GetNewTraceSource(nameof(MsalCacheHelper) + "Singleton");
         });
 
-        private static readonly Lazy<MsalCacheStorage> s_staticStore = new Lazy<MsalCacheStorage>(() =>
-        {
-            return new MsalCacheStorage(s_storageCreationProperties, logger: s_staticLogger.Value);
-        });
-
-        private static StorageCreationProperties s_storageCreationProperties;
+        /// <summary>
+        /// Properties used to create storage on disk.
+        /// </summary>
+        private readonly StorageCreationProperties _storageCreationProperties;
 
         /// <summary>
         /// Holds a lock object when this helper is accessing the cache. Null otherwise.
@@ -48,50 +49,34 @@ namespace Microsoft.Identity.Client.Extensions.Msal
         /// <summary>
         /// Gets the token cache
         /// </summary>
-        private readonly ITokenCache _userTokenCache;
+        private ITokenCache _userTokenCache;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="MsalCacheHelper"/> class.
-        ///
-        /// FOR TESTING ONLY!
+        /// Creates a new instance of this class.
         /// </summary>
-        /// <param name="tokenCache">token cache</param>
-        /// <param name="storage">Adal cache storage</param>
-        /// <param name="logger">Logger</param>
-        internal MsalCacheHelper(ITokenCache tokenCache, MsalCacheStorage storage, TraceSource logger)
+        /// <param name="storageCreationProperties">Properties to use when creating storage on disk.</param>
+        /// <param name="logger">Passing null uses the default logger</param>
+        public MsalCacheHelper(StorageCreationProperties storageCreationProperties, TraceSource logger = null)
         {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _store = storage ?? throw new ArgumentNullException(nameof(storage));
+            _logger = logger ?? s_staticLogger.Value;
+            _storageCreationProperties = storageCreationProperties;
+            _store = new MsalCacheStorage(_storageCreationProperties, logger);
 
-            // Normally this is set by RegisterCache, but that doesn't get called in tests.
-            s_storageCreationProperties = storage._creationProperties;
+        }
 
-            _userTokenCache = tokenCache ?? throw new ArgumentNullException(nameof(tokenCache));
+        /// <summary>
+        /// An internal constructor allowing unit tests to data explicitly rather than initializing here.
+        /// </summary>
+        /// <param name="userTokenCache">The token cache to synchronize with the backing store</param>
+        /// <param name="store">The backing store to use.</param>
+        /// <param name="logger">Passing null uses the default logger</param>
+        internal MsalCacheHelper(ITokenCache userTokenCache, MsalCacheStorage store, TraceSource logger = null)
+        {
+            _logger = logger ?? s_staticLogger.Value;
+            _store = store;
+            _storageCreationProperties = store._creationProperties;
 
-            _userTokenCache.SetBeforeAccess(BeforeAccessNotification);
-            _userTokenCache.SetAfterAccess(AfterAccessNotification);
-
-            _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Initializing adal cache");
-
-            byte[] data = _store.ReadData();
-
-            _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Read '{data?.Length}' bytes from storage");
-
-            if (data != null && data.Length > 0)
-            {
-                try
-                {
-                    _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Deserializing data into memory");
-                    _userTokenCache.DeserializeMsalV3(data);
-                }
-                catch (Exception e)
-                {
-                    _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"An exception was encountered while deserializing the data during initialization of {nameof(MsalCacheHelper)} : {e}");
-                    _store.Clear();
-                }
-            }
-
-            _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Done initializing");
+            RegisterCache(userTokenCache);
         }
 
         /// <summary>
@@ -106,35 +91,55 @@ namespace Microsoft.Identity.Client.Extensions.Msal
         }
 
         /// <summary>
+        /// Gets whether this instance has had <see cref="RegisterCache(ITokenCache)" /> called.
+        /// </summary>
+        public bool Registerred { get; private set; }
+
+        /// <summary>
         /// Gets a singleton instance of the TokenCacheHelper
         /// </summary>
         /// <param name="tokenCache">Token Cache</param>
-        /// <param name="storageProperties">Properties to use when creating the storage on disk</param>
         /// <returns>token cache helper</returns>
-        public static MsalCacheHelper RegisterCache(ITokenCache tokenCache, StorageCreationProperties storageProperties)
+        public void RegisterCache(ITokenCache tokenCache)
         {
             lock (s_lockObject)
             {
-                try
+                _userTokenCache = tokenCache ?? throw new ArgumentNullException(nameof(tokenCache));
+
+                _userTokenCache.SetBeforeAccess(BeforeAccessNotification);
+                _userTokenCache.SetAfterAccess(AfterAccessNotification);
+
+                _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Initializing msal cache");
+
+                byte[] data = _store.ReadData();
+
+                _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Read '{data?.Length}' bytes from storage");
+
+                if (data != null && data.Length > 0)
                 {
-                    s_storageCreationProperties = storageProperties;
-                    s_staticLogger.Value.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Creating '{nameof(RegisterCache)}'");
-                    return new MsalCacheHelper(tokenCache, s_staticStore.Value, s_staticLogger.Value);
+                    try
+                    {
+                        _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Deserializing data into memory");
+                        _userTokenCache.DeserializeMsalV3(data);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"An exception was encountered while deserializing the data during initialization of {nameof(MsalCacheHelper)} : {e}");
+                        _store.Clear();
+                    }
                 }
-                catch (Exception e)
-                when (SharedUtilities.LogExceptionAndDoNotHandle(() => s_staticLogger.Value.TraceEvent(TraceEventType.Error, /*id*/ 0, $"Problem creating '{nameof(RegisterCache)}' : '{e}'")))
-                {
-                    throw;
-                }
+
+                Registerred = true;
+                _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Done initializing");
             }
         }
 
         /// <summary>
         /// Clears the token store
         /// </summary>
-        public static void Clear()
+        public void Clear()
         {
-            s_staticStore.Value.Clear();
+            _store.Clear();
         }
 
         /// <summary>
@@ -147,8 +152,8 @@ namespace Microsoft.Identity.Client.Extensions.Msal
 
             _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Acquiring lock for token cache");
             CacheLock = new CrossPlatLock(
-                Path.GetFileNameWithoutExtension(s_storageCreationProperties.CacheFileName),
-                Path.Combine(s_storageCreationProperties.CacheDirectory, s_storageCreationProperties.CacheFileName) + ".lockfile");
+                Path.GetFileNameWithoutExtension(_storageCreationProperties.CacheFileName),
+                Path.Combine(_storageCreationProperties.CacheDirectory, _storageCreationProperties.CacheFileName) + ".lockfile");
 
             if (_store.HasChanged)
             {

--- a/tests/ManualTestApp/Utilities.cs
+++ b/tests/ManualTestApp/Utilities.cs
@@ -46,7 +46,9 @@ namespace ManualTestApp
             var storageCreationProps = storageCreationPropsBuilder.Build();
 
             // This hooks up our custom cache onto the one used by MSAL
-            var cacheHelper = MsalCacheHelper.RegisterCache(app.UserTokenCache, storageCreationProps);
+            var cacheHelper = new MsalCacheHelper(storageCreationProps);
+            cacheHelper.RegisterCache(app.UserTokenCache);
+
             Console.WriteLine($"Cache registered");
 
             return (scopes, app, cacheHelper);


### PR DESCRIPTION
Update MsalCacheHelper to have fewer statics and provide a way to create a helper without registering so that users can clear the cache without a public app.