### PR TITLE
Add target for .NET Standard 2.0 to extension projects

### DIFF
--- a/src/Microsoft.Identity.Client.Extensions.Adal/Microsoft.Identity.Client.Extensions.Adal.csproj
+++ b/src/Microsoft.Identity.Client.Extensions.Adal/Microsoft.Identity.Client.Extensions.Adal.csproj
@@ -7,7 +7,7 @@
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
     <Version>$(ClientSemVer)</Version>
 
-    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net45;netstandard2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);ADAL</DefineConstants>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>

--- a/src/Microsoft.Identity.Client.Extensions.Msal/Microsoft.Identity.Client.Extensions.Msal.csproj
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/Microsoft.Identity.Client.Extensions.Msal.csproj
@@ -7,7 +7,7 @@
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
     <Version>$(ClientSemVer)</Version>
 
-    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net45;netstandard2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);MSAL</DefineConstants>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>


### PR DESCRIPTION
Adding a `netstandard2.0` target to both MSAL and ADAL packages to match target used in both client packages.