### PR TITLE
Jpwilli/remove identity service path

### DIFF
--- a/src/Microsoft.Identity.Client.Extensions.Adal/AdalCache.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Adal/AdalCache.cs
@@ -69,9 +69,7 @@ namespace Microsoft.Identity.Client.Extensions.Adal
             _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Before access");
 
             _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Acquiring lock for token cache");
-            _cacheLock = new CrossPlatLock(
-                Path.GetFileNameWithoutExtension(_store.CreationProperties.CacheFileName),
-                Path.Combine(_store.CreationProperties.CacheDirectory, _store.CreationProperties.CacheFileName) + ".lockfile");
+            _cacheLock = new CrossPlatLock(Path.Combine(_store.CreationProperties.CacheDirectory, _store.CreationProperties.CacheFileName) + ".lockfile");
 
             if (_store.HasChanged)
             {

--- a/src/Microsoft.Identity.Client.Extensions.Adal/AdalCacheStorage.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Adal/AdalCacheStorage.cs
@@ -15,6 +15,14 @@ namespace Microsoft.Identity.Client.Extensions.Adal
     /// </summary>
     public sealed class AdalCacheStorage
     {
+        /// <summary>
+        /// A default logger for use if the user doesn't want to provide their own.
+        /// </summary>
+        private static readonly Lazy<TraceSource> s_staticLogger = new Lazy<TraceSource>(() =>
+        {
+            return (TraceSource)EnvUtils.GetNewTraceSource(nameof(AdalCacheStorage) + "Singleton");
+        });
+
         private const int FileLockRetryCount = 20;
         private const int FileLockRetryWaitInMs = 200;
 
@@ -36,8 +44,8 @@ namespace Microsoft.Identity.Client.Extensions.Adal
         /// <param name="logger">logger</param>
         public AdalCacheStorage(StorageCreationProperties creationProperties, TraceSource logger)
         {
+            _logger = logger ?? s_staticLogger.Value;
             CreationProperties = creationProperties ?? throw new ArgumentNullException(nameof(creationProperties));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
             logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Initializing '{nameof(AdalCacheStorage)}' with cacheFilePath '{creationProperties.CacheDirectory}'");
 
@@ -65,7 +73,7 @@ namespace Microsoft.Identity.Client.Extensions.Adal
         {
             get
             {
-                return SharedUtilities.GetDefaultArtifactPath();
+                return SharedUtilities.GetUserRootDirectory();
             }
         }
 

--- a/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheHelper.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheHelper.cs
@@ -146,9 +146,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal
             _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Before access");
 
             _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Acquiring lock for token cache");
-            CacheLock = new CrossPlatLock(
-                Path.GetFileNameWithoutExtension(_storageCreationProperties.CacheFileName),
-                Path.Combine(_storageCreationProperties.CacheDirectory, _storageCreationProperties.CacheFileName) + ".lockfile");
+            CacheLock = new CrossPlatLock(Path.Combine(_storageCreationProperties.CacheDirectory, _storageCreationProperties.CacheFileName) + ".lockfile");
 
             if (_store.HasChanged)
             {

--- a/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheHelper.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheHelper.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal
         {
             get
             {
-                return SharedUtilities.GetDefaultArtifactPath();
+                return SharedUtilities.GetUserRootDirectory();
             }
         }
 

--- a/src/Shared/CrossPlatLock.cs
+++ b/src/Shared/CrossPlatLock.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -18,31 +19,12 @@ namespace Microsoft.Identity.Client.Extensions.Web
 {
     internal class CrossPlatLock : IDisposable
     {
-        private const bool UseMutex = false;
-        private const int MutexTimeout = 60000;
-        private const int LockfileRetryCount = 6000;
-        private const int LockfileRetryWait = 10;
-        private Mutex _mutex;
+        private const int LockfileRetryWait = 100;
+        private const int LockfileRetryCount = 60000 / LockfileRetryWait;
         private FileStream _lockFileStream;
-        private string _lockFilePath;
 
-        public CrossPlatLock(string simpleName, string lockfilePath)
+        public CrossPlatLock(string lockfilePath)
         {
-#pragma warning disable CS0162 // Unreachable code detected
-            if (UseMutex)
-            {
-                InitializeMutex(simpleName);
-            }
-            else
-            {
-                InitializeLockfileAsync(lockfilePath);
-            }
-#pragma warning restore CS0162 // Unreachable code detected
-        }
-
-        private void InitializeLockfileAsync(string lockfilePath)
-        {
-            _lockFilePath = lockfilePath;
             Exception exception = null;
             FileStream fileStream = null;
             for (int tryCount = 0; tryCount < LockfileRetryCount; tryCount++)
@@ -53,8 +35,12 @@ namespace Microsoft.Identity.Client.Extensions.Web
                 {
                     // We are using the file locking to synchronize the store, do not allow multiple writers or readers for the file.
                     const int defaultBufferSize = 4096;
-                    fileStream = new FileStream(lockfilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None, defaultBufferSize, FileOptions.DeleteOnClose);
-                    break;
+                    fileStream = new FileStream(lockfilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read, defaultBufferSize, FileOptions.DeleteOnClose);
+                    using (var writer = new StreamWriter(fileStream, Encoding.UTF8, defaultBufferSize, leaveOpen: true))
+                    {
+                        writer.WriteLine($"{Process.GetCurrentProcess().Id} {Process.GetCurrentProcess().ProcessName}");
+                    }
+                        break;
                 }
                 catch (IOException ex)
                 {
@@ -66,36 +52,8 @@ namespace Microsoft.Identity.Client.Extensions.Web
             _lockFileStream = fileStream ?? throw new InvalidOperationException("Could not get access to the shared lock file.", exception);
         }
 
-        private void InitializeMutex(string simpleName)
-        {
-            var mutex = new Mutex(initiallyOwned: false, name: $@"Global\{simpleName}");
-            bool mutexAcquired;
-
-            try
-            {
-                mutexAcquired = mutex.WaitOne(MutexTimeout);
-            }
-            catch (AbandonedMutexException)
-            {
-                // Abandoned mutexes are still acquired. Just treat as acquisition.
-                mutexAcquired = true;
-            }
-
-            // Handle timeout
-            if (!mutexAcquired)
-            {
-                throw new TimeoutException($"Unable to acquire mutex in {MutexTimeout} milliseconds");
-            }
-
-            _mutex = mutex;
-        }
-
         public void Dispose()
         {
-            _mutex?.ReleaseMutex();
-            _mutex?.Dispose();
-            _mutex = null;
-
             _lockFileStream?.Dispose();
             _lockFileStream = null;
         }

--- a/src/Shared/SharedUtilities.cs
+++ b/src/Shared/SharedUtilities.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Identity.Client.Extensions.Web
         /// <summary>
         /// default base cache path
         /// </summary>
-        private const string DefaultBaseCachePath = ".IdentityService";
         private static readonly string s_homeEnvVar = Environment.GetEnvironmentVariable("HOME");
         private static readonly string s_lognameEnvVar = Environment.GetEnvironmentVariable("LOGNAME");
         private static readonly string s_userEnvVar = Environment.GetEnvironmentVariable("USER");

--- a/src/Shared/SharedUtilities.cs
+++ b/src/Shared/SharedUtilities.cs
@@ -52,15 +52,6 @@ namespace Microsoft.Identity.Client.Extensions.Web
         }
 
         /// <summary>
-        /// Generate the default artifact location
-        /// </summary>
-        /// <returns>Default artifact location</returns>
-        public static string GetDefaultArtifactPath()
-        {
-            return Path.Combine(SharedUtilities.GetRootDirectory(), SharedUtilities.DefaultBaseCachePath);
-        }
-
-        /// <summary>
         ///  Is this a windows platform
         /// </summary>
         /// <returns>A  value indicating if we are running on windows or not</returns>
@@ -95,15 +86,6 @@ namespace Microsoft.Identity.Client.Extensions.Web
 #else
             return System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux);
 #endif
-        }
-
-        /// <summary>
-        /// Gets the users root directory
-        /// </summary>
-        /// <returns>Root directory</returns>
-        public static string GetRootDirectory()
-        {
-            return GetUserRootDirectory();
         }
 
         /// <summary>

--- a/tests/Microsoft.Identity.Client.Extensions.Adal.UnitTests/AdalCacheStorageTests.cs
+++ b/tests/Microsoft.Identity.Client.Extensions.Adal.UnitTests/AdalCacheStorageTests.cs
@@ -46,6 +46,12 @@ namespace Microsoft.Identity.Client.Extensions.Adal.UnitTests
         }
 
         [TestMethod]
+        public void AdalTestUserDirectory()
+        {
+            Assert.AreEqual(AdalCacheStorage.UserRootDirectory, Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
+        }
+
+        [TestMethod]
         public void AdalNewStoreNoFile()
         {
             var store = new AdalCacheStorage(s_storageCreationProperties, logger: _logger);

--- a/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/MsalCacheStorageTests.cs
+++ b/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/MsalCacheStorageTests.cs
@@ -47,6 +47,12 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
         }
 
         [TestMethod]
+        public void MsalTestUserDirectory()
+        {
+            Assert.AreEqual(MsalCacheHelper.UserRootDirectory, Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
+        }
+
+        [TestMethod]
         public void MsalNewStoreNoFile()
         {
             var store = new MsalCacheStorage(s_storageCreationProperties, logger: _logger);


### PR DESCRIPTION
Removes the last reference to "IdentityService" from shipping code (although it still exists in tests). Also fixes a small issue with logging where users could give null TraceSource objects and cause problems.