### PR TITLE
bring in remaining web extensions code

### DIFF
--- a/src/Microsoft.Identity.Client.Extensions.Web/AccountExtensions.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/AccountExtensions.cs
@@ -6,7 +6,7 @@ using System.Security.Claims;
 namespace Microsoft.Identity.Client.Extensions.Web
 {
     /// <summary>
-    /// 
+    /// Extension methods dealing with IAccount instances.
     /// </summary>
     public static class AccountExtensions
     {

--- a/src/Microsoft.Identity.Client.Extensions.Web/ClaimConstants.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/ClaimConstants.cs
@@ -5,14 +5,8 @@ namespace Microsoft.Identity.Client.Extensions.Web
 {
     internal static class ClaimConstants
     {
-        /// <summary>
-        /// 
-        /// </summary>
         public const string ObjectId = "http://schemas.microsoft.com/identity/claims/objectidentifier";
-
-        /// <summary>
-        /// 
-        /// </summary>
         public const string TenantId = "http://schemas.microsoft.com/identity/claims/tenantid";
+        public const string TidKey = "tid";
     }
 }

--- a/src/Microsoft.Identity.Client.Extensions.Web/ClaimsPrincipalExtensions.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/ClaimsPrincipalExtensions.cs
@@ -7,7 +7,7 @@ using System.Security.Claims;
 namespace Microsoft.Identity.Client.Extensions.Web
 {
     /// <summary>
-    /// 
+    /// Extensions around ClaimsPrincipal.
     /// </summary>
     public static class ClaimsPrincipalExtensions
     {
@@ -15,7 +15,7 @@ namespace Microsoft.Identity.Client.Extensions.Web
         /// Get the Account identifier for an MSAL.NET account from a ClaimsPrincipal
         /// </summary>
         /// <param name="claimsPrincipal">Claims principal</param>
-        /// <returns>A string corresponding to an account identifier as defined in <see cref="Microsoft.Identity.Client.AccountId.Identifier"/></returns>
+        /// <returns>A string corresponding to an account identifier as defined in <see cref="AccountId.Identifier"/></returns>
         public static string GetMsalAccountId(this ClaimsPrincipal claimsPrincipal)
         {
             string userObjectId = claimsPrincipal.GetObjectId();

--- a/src/Microsoft.Identity.Client.Extensions.Web/ClaimsPrincipalFactory.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/ClaimsPrincipalFactory.cs
@@ -6,7 +6,7 @@ using System.Security.Claims;
 namespace Microsoft.Identity.Client.Extensions.Web
 {
     /// <summary>
-    /// 
+    /// Factory class to create ClaimsPrincipal objects.
     /// </summary>
     public static class ClaimsPrincipalFactory
     {

--- a/src/Microsoft.Identity.Client.Extensions.Web/ITokenAcquisition.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/ITokenAcquisition.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.Identity.Client.Extensions.Web
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface ITokenAcquisition
+    {
+        /// <summary>
+        /// In a Web App, adds, to the MSAL.NET cache, the account of the user authenticating to the Web App, when the authorization code is received (after the user
+        /// signed-in and consented)
+        /// An On-behalf-of token contained in the <see cref="AuthorizationCodeReceivedContext"/> is added to the cache, so that it can then be used to acquire another token on-behalf-of the 
+        /// same user in order to call to downstream APIs.
+        /// </summary>
+        /// <param name="context">The context used when an 'AuthorizationCode' is received over the OpenIdConnect protocol.</param>
+        /// <param name="scopes"></param>
+        /// <example>
+        /// From the configuration of the Authentication of the ASP.NET Core Web API: 
+        /// <code>OpenIdConnectOptions options;</code>
+        /// 
+        /// Subscribe to the authorization code recieved event:
+        /// <code>
+        ///  options.Events = new OpenIdConnectEvents();
+        ///  options.Events.OnAuthorizationCodeReceived = OnAuthorizationCodeReceived;
+        /// }
+        /// </code>
+        /// 
+        /// And then in the OnAuthorizationCodeRecieved method, call <see cref="AddAccountToCacheFromAuthorizationCodeAsync"/>:
+        /// <code>
+        /// private async Task OnAuthorizationCodeReceived(AuthorizationCodeReceivedContext context)
+        /// {
+        ///   var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService&lt;ITokenAcquisition&gt;();
+        ///    await _tokenAcquisition.AddAccountToCacheFromAuthorizationCode(context, new string[] { "user.read" });
+        /// }
+        /// </code>
+        /// </example>
+        Task AddAccountToCacheFromAuthorizationCodeAsync(AuthorizationCodeReceivedContext context, IEnumerable<string> scopes);
+
+        /// <summary>
+        /// Typically used from an ASP.NET Core Web App or Web API controller, this method gets an access token 
+        /// for a downstream API on behalf of the user account which claims are provided in the <see cref="HttpContext.User"/>
+        /// member of the <paramref name="context"/> parameter
+        /// </summary>
+        /// <param name="context">HttpContext associated with the Controller or auth operation</param>
+        /// <param name="scopes">Scopes to request for the downstream API to call</param>
+        /// <param name="tenantId">Enables to override the tenant/account for the same identity. This is useful in the 
+        /// cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant</param>
+        /// <returns>An access token to call on behalf of the user, the downstream API characterized by its scopes</returns>
+        Task<string> GetAccessTokenOnBehalfOfUserAsync(HttpContext context, IEnumerable<string> scopes, string tenantId = null);
+
+        /// <summary>
+        /// In a Web API, adds to the MSAL.NET cache, the account of the user for which a bearer token was received when the Web API was called.
+        /// An access token and a refresh token are added to the cache, so that they can then be used to acquire another token on-behalf-of the 
+        /// same user in order to call to downstream APIs.
+        /// </summary>
+        /// <param name="tokenValidationContext">Token validation context passed to the handler of the OnTokenValidated event
+        /// for the JwtBearer middleware</param>
+        /// <param name="scopes">[Optional] scopes to pre-request for a downstream API</param>
+        /// <example>
+        /// From the configuration of the Authentication of the ASP.NET Core Web API (for example in the Startup.cs file)
+        /// <code>JwtBearerOptions option;</code>
+        /// 
+        /// Subscribe to the token validated event:
+        /// <code>
+        /// options.Events = new JwtBearerEvents();
+        /// options.Events.OnTokenValidated = async context =>
+        /// {
+        ///   var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService&lt;ITokenAcquisition&gt;();
+        ///   tokenAcquisition.AddAccountToCacheFromJwt(context);
+        /// };
+        /// </code>
+        /// </example>
+        Task AddAccountToCacheFromJwtAsync(
+            AspNetCore.Authentication.JwtBearer.TokenValidatedContext tokenValidationContext,
+            IEnumerable<string> scopes = null);
+
+        /// <summary>
+        /// [not recommended] In a Web App, adds, to the MSAL.NET cache, the account of the user authenticating to the Web App.
+        /// An On-behalf-of token is added to the cache, so that it can then be used to acquire another token on-behalf-of the 
+        /// same user in order for the Web App to call a Web APIs.
+        /// </summary>
+        /// <param name="tokenValidationContext">Token validation context passed to the handler of the OnTokenValidated event 
+        /// for the OpenIdConnect middleware</param>
+        /// <param name="scopes">[Optional] scopes to pre-request for a downstream API</param>
+        /// <remarks>In a Web App, it's preferable to not request an access token, but only a code, and use the <see cref="AddAccountToCacheFromAuthorizationCodeAsync"/></remarks>
+        /// <example>
+        /// From the configuration of the Authentication of the ASP.NET Core Web API: 
+        /// <code>OpenIdConnectOptions options;</code>
+        /// 
+        /// Subscribe to the token validated event:
+        /// <code>
+        ///  options.Events.OnAuthorizationCodeReceived = OnTokenValidated;
+        /// </code>
+        /// 
+        /// And then in the OnTokenValidated method, call <see cref="AddAccountToCacheFromJwtAsync(TokenValidatedContext, IEnumerable&lt;string&gt;)"/>:
+        /// <code>
+        /// private async Task OnTokenValidated(TokenValidatedContext context)
+        /// {
+        ///   var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService&lt;ITokenAcquisition&gt;();
+        ///  _tokenAcquisition.AddAccountToCache(tokenValidationContext);
+        /// }
+        /// </code>
+        /// </example>
+        Task AddAccountToCacheFromJwtAsync(
+            TokenValidatedContext tokenValidationContext,
+            IEnumerable<string> scopes = null);
+
+        /// <summary>
+        /// Removes the account associated with context.HttpContext.User from the MSAL.NET cache
+        /// </summary>
+        /// <param name="context">RedirectContext passed-in to a Openidconnect event</param>
+        /// <returns></returns>
+        Task RemoveAccountAsync(RedirectContext context);
+
+        /// <summary>
+        /// Used in Web APIs (which therefore cannot have an interaction with the user). 
+        /// Replies to the client through the HttpReponse by sending a 403 (forbidden) and populating wwwAuthenticateHeaders so that
+        /// the client can trigger an iteraction with the user so that the user consents to more scopes
+        /// </summary>
+        /// <param name="httpContext">HttpContext</param>
+        /// <param name="scopes">Scopes to consent to</param>
+        /// <param name="msalSeviceException"><see cref="MsalUiRequiredException"/> triggering the challenge</param>
+        void ReplyForbiddenWithWwwAuthenticateHeader(
+            HttpContext httpContext,
+            IEnumerable<string> scopes,
+            MsalUiRequiredException msalSeviceException);
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/Microsoft.Identity.Client.Extensions.Web.csproj
+++ b/src/Microsoft.Identity.Client.Extensions.Web/Microsoft.Identity.Client.Extensions.Web.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0"/>
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="2.1.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="3.0.2-preview" />

--- a/src/Microsoft.Identity.Client.Extensions.Web/MsalUiRequiredExceptionFilterAttribute.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/MsalUiRequiredExceptionFilterAttribute.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Client.Extensions.Web
             // InMemoryCache, the cache could be empty if the server was restarted. This is why
             // the null_user exception is thrown.
 
-            return ex.ErrorCode == MsalUiRequiredException.UserNullError;
+            return ex.ErrorCode == MsalError.UserNullError;
         }
 
         /// <summary>

--- a/src/Microsoft.Identity.Client.Extensions.Web/MsalUiRequiredExceptionFilterAttribute.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/MsalUiRequiredExceptionFilterAttribute.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace Microsoft.Identity.Client.Extensions.Web
+{
+    /// <summary>
+    /// Filter used on a controller action to trigger an incremental consent.
+    /// </summary>
+    /// <example>
+    /// The following controller action will trigger 
+    /// <code>
+    /// [MsalUiRequiredExceptionFilter(Scopes = new[] {"Mail.Send"})]
+    /// public async Task&lt;IActionResult&gt; SendEmail()
+    /// {
+    /// }
+    /// </code>
+    /// </example>
+    public class MsalUiRequiredExceptionFilterAttribute : ExceptionFilterAttribute
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public string[] Scopes { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="context"></param>
+        public override void OnException(ExceptionContext context)
+        {
+            if (context.Exception is MsalUiRequiredException msalUiRequiredException)
+            {
+                if (CanBeSolvedByReSignInUser(msalUiRequiredException))
+                {
+                    var properties = BuildAuthenticationPropertiesForIncrementalConsent(
+                        Scopes,
+                        msalUiRequiredException,
+                        context.HttpContext);
+                    context.Result = new ChallengeResult(properties);
+                }
+            }
+
+            base.OnException(context);
+        }
+
+        private bool CanBeSolvedByReSignInUser(MsalUiRequiredException ex)
+        {
+            // ex.ErrorCode != MsalUiRequiredException.UserNullError indicates a cache problem.
+            // When calling an [Authenticate]-decorated controller we expect an authenticated
+            // user and therefore its account should be in the cache. However in the case of an
+            // InMemoryCache, the cache could be empty if the server was restarted. This is why
+            // the null_user exception is thrown.
+
+            return ex.ErrorCode == MsalUiRequiredException.UserNullError;
+        }
+
+        /// <summary>
+        /// Build Authentication properties needed for an incremental consent.
+        /// </summary>
+        /// <param name="scopes">Scopes to request</param>
+        /// <param name="ex">ui is present</param>
+        /// <param name="context">current http context in the pipeline</param>
+        /// <returns>AuthenticationProperties</returns>
+        private AuthenticationProperties BuildAuthenticationPropertiesForIncrementalConsent(
+            string[] scopes, MsalUiRequiredException ex, HttpContext context)
+        {
+            var properties = new AuthenticationProperties();
+
+            // Set the scopes, including the scopes that ADAL.NET / MASL.NET need for the Token cache
+            string[] additionalBuildInScopes = {
+                OidcConstants.ScopeOpenId,
+                OidcConstants.ScopeOfflineAccess,
+                OidcConstants.ScopeProfile
+            };
+
+            properties.SetParameter<ICollection<string>>(
+                OpenIdConnectParameterNames.Scope,
+                scopes.Union(additionalBuildInScopes).ToList());
+
+            // Attempts to set the login_hint to avoid the logged-in user to be presented with an account selection dialog
+            var loginHint = context.User.GetLoginHint();
+            if (!string.IsNullOrWhiteSpace(loginHint))
+            {
+                properties.SetParameter(OpenIdConnectParameterNames.LoginHint, loginHint);
+
+                var domainHint = context.User.GetDomainHint();
+                properties.SetParameter(OpenIdConnectParameterNames.DomainHint, domainHint);
+            }
+
+            // Additional claims required (for instance MFA)
+            if (!string.IsNullOrEmpty(ex.Claims))
+            {
+                properties.Items.Add(OidcConstants.AdditionalClaims, ex.Claims);
+            }
+
+            return properties;
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/OidcConstants.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/OidcConstants.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Identity.Client.Extensions.Web
+{
+    internal static class OidcConstants
+    {
+        public const string AdditionalClaims = "claims";
+        public const string ScopeOfflineAccess = "offline_access";
+        public const string ScopeProfile = "profile";
+        public const string ScopeOpenId = "openid";
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/Resource/AadIssuerValidator.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/Resource/AadIssuerValidator.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Text;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Microsoft.Identity.Client.Extensions.Web.Resource
+{
+    /// <summary>
+    /// Generic class that validates token issuer from the provided Azure AD authority
+    /// </summary>
+    public class AadIssuerValidator
+    {
+        /// <summary>
+        /// A list of all Issuers across the various Azure AD instances
+        /// </summary>
+        private readonly SortedSet<string> _issuerAliases;
+
+        private const string FallBackAuthority = "https://login.microsoftonline.com/";
+
+        private static readonly IDictionary<string, AadIssuerValidator> s_issuerValidators = new Dictionary<string, AadIssuerValidator>();
+
+        private AadIssuerValidator(IEnumerable<string> aliases)
+        {
+            _issuerAliases = new SortedSet<string>(aliases);
+        }
+
+        /// <summary>
+        /// Retrieves the AadIssuerValidator for a given authority
+        /// </summary>
+        /// <param name="aadAuthority"></param>
+        /// <returns></returns>
+        public static AadIssuerValidator ForAadInstance(string aadAuthority)
+        {
+            if (s_issuerValidators.ContainsKey(aadAuthority))
+            {
+                return s_issuerValidators[aadAuthority];
+            }
+            else
+            {
+                string authorityHost = new Uri(aadAuthority).Authority;
+                // In the constructor, we hit the Azure AD issuer metadata endpoint and cache the aliases. The data is cached for 24 hrs.
+                string azureADIssuerMetadataUrl = "https://login.microsoftonline.com/common/discovery/instance?authorization_endpoint=https://login.microsoftonline.com/common/oauth2/v2.0/authorize&api-version=1.1";
+                ConfigurationManager<IssuerMetadata> configManager = new ConfigurationManager<IssuerMetadata>(azureADIssuerMetadataUrl, new IssuerConfigurationRetriever());
+                IssuerMetadata issuerMetadata = configManager.GetConfigurationAsync().Result;
+
+                // Add issuer aliases of the chosen authority
+                string authority = authorityHost ?? FallBackAuthority;
+                var aliases = issuerMetadata.Metadata.Where(m => m.Aliases.Any(a => a == authority)).SelectMany(m => m.Aliases).Distinct();
+                AadIssuerValidator issuerValidator = new AadIssuerValidator(aliases);
+
+                s_issuerValidators.Add(authority, issuerValidator);
+                return issuerValidator;
+            }
+        }
+
+        /// <summary>
+        /// Validate the issuer for multi-tenant applications of various audience (Work and School account, or Work and School accounts +
+        /// Personal accounts)
+        /// </summary>
+        /// <param name="issuer">Issuer to validate (will be tenanted)</param>
+        /// <param name="securityToken">Received Security Token</param>
+        /// <param name="validationParameters">Token Validation parameters</param>
+        /// <remarks>The issuer is considered as valid if it has the same http scheme and authority as the
+        /// authority from the configuration file, has a tenant Id, and optionally v2.0 (this web api
+        /// accepts both V1 and V2 tokens).
+        /// Authority aliasing is also taken into account</remarks>
+        /// <returns>The <c>issuer</c> if it's valid, or otherwise <c>SecurityTokenInvalidIssuerException</c> is thrown</returns>
+        public string ValidateAadIssuer(string issuer, SecurityToken securityToken, TokenValidationParameters validationParameters)
+        {
+            JwtSecurityToken jwtToken = securityToken as JwtSecurityToken;
+            if (jwtToken == null)
+            {
+                throw new ArgumentNullException(nameof(securityToken), $"{nameof(securityToken)} cannot be null.");
+            }
+
+            if (validationParameters == null)
+            {
+                throw new ArgumentNullException(nameof(validationParameters), $"{nameof(validationParameters)} cannot be null.");
+            }
+
+            string tenantId = GetTenantIdFromClaims(jwtToken);
+            if (string.IsNullOrWhiteSpace(tenantId))
+            {
+                throw new SecurityTokenInvalidIssuerException("Neither `tid` nor `tenantId` claim is present in the token obtained from Microsoft Identity Platform.");
+            }
+
+            // Build a list of valid tenanted issuers from the provided TokenValidationParameters.
+            List<string> allValidTenantedIssuers = new List<string>();
+
+            IEnumerable<string> validIssuers = validationParameters.ValidIssuers;
+            if (validIssuers != null)
+            {
+                allValidTenantedIssuers.AddRange(validIssuers.Select(i => TenantedIssuer(i, tenantId)));
+            }
+
+            if (validationParameters.ValidIssuer != null)
+            {
+                allValidTenantedIssuers.Add(TenantedIssuer(validationParameters.ValidIssuer, tenantId));
+            }
+
+            // Looking for a valid issuer which authority would be one of the aliases of the authority declared in the
+            // Web app / Web API, and which tenantId would be the one for the token
+            foreach (string validIssuer in allValidTenantedIssuers)
+            {
+                Uri uri = new Uri(validIssuer);
+                if (_issuerAliases.Contains(uri.Authority))
+                {
+                    string trimmedLocalPath = uri.LocalPath.Trim('/');
+                    if (trimmedLocalPath == tenantId || trimmedLocalPath == $"{tenantId}/v2.0")
+                    {
+                        return issuer;
+                    }
+                }
+            }
+
+            // If a valid issuer is not found, throw
+            throw new SecurityTokenInvalidIssuerException("Issuer does not match any of the valid issuers provided for this application.");
+        }
+
+        /// <summary>Gets the tenant id from claims.</summary>
+        /// <param name="jwtToken">The JWT token with the claims collection.</param>
+        /// <returns>A string containing tenantId, if found or an empty string</returns>
+        private string GetTenantIdFromClaims(JwtSecurityToken jwtToken)
+        {
+            string tenantId;
+
+            // Extract the tenant Id from the claims
+            tenantId = jwtToken.Claims.FirstOrDefault(c => c.Type == ClaimConstants.TidKey)?.Value;
+
+            if (string.IsNullOrWhiteSpace(tenantId))
+            {
+                tenantId = jwtToken.Claims.FirstOrDefault(c => c.Type == ClaimConstants.TenantId)?.Value;
+            }
+
+            return tenantId;
+        }
+
+        private static string TenantedIssuer(string i, string tenantId)
+        {
+            return i.Replace("{tenantid}", tenantId);
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/Resource/IssuerConfigurationRetriever.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/Resource/IssuerConfigurationRetriever.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Protocols;
+using Newtonsoft.Json;
+
+namespace Microsoft.Identity.Client.Extensions.Web.Resource
+{
+    /// <summary>
+    /// An implementation of IConfigurationRetriever geared towards Azure AD issuers metadata />
+    /// </summary>
+    public class IssuerConfigurationRetriever : IConfigurationRetriever<IssuerMetadata>
+    {
+        /// <summary>Retrieves a populated configuration given an address and an <see cref="T:Microsoft.IdentityModel.Protocols.IDocumentRetriever"/>.</summary>
+        /// <param name="address">Address of the discovery document.</param>
+        /// <param name="retriever">The <see cref="T:Microsoft.IdentityModel.Protocols.IDocumentRetriever"/> to use to read the discovery document.</param>
+        /// <param name="cancel">A cancellation token that can be used by other objects or threads to receive notice of cancellation. <see cref="T:System.Threading.CancellationToken"/>.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException">address - Azure AD Issuer metadata address url is required
+        /// or
+        /// retriever - No metadata document retriever is provided</exception>
+        public async Task<IssuerMetadata> GetConfigurationAsync(string address, IDocumentRetriever retriever, CancellationToken cancel)
+        {
+            if (string.IsNullOrWhiteSpace(address))
+            {
+                throw new ArgumentNullException(nameof(address), $"Azure AD Issuer metadata address url is required");
+            }
+
+            if (retriever == null)
+            {
+                throw new ArgumentNullException(nameof(retriever), $"No metadata document retriever is provided");
+            }
+
+            string doc = await retriever.GetDocumentAsync(address, cancel).ConfigureAwait(false);
+            IssuerMetadata metadata = JsonConvert.DeserializeObject<IssuerMetadata>(doc);
+
+            return metadata;
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/Resource/IssuerMetadata.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/Resource/IssuerMetadata.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.Identity.Client.Extensions.Web.Resource
+{
+    /// <summary>
+    /// Model class to hold information parsed from the Azure AD issuer endpoint
+    /// </summary>
+    public class IssuerMetadata
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty(PropertyName = "tenant_discovery_endpoint")]
+        public string TenantDiscoveryEndpoint { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty(PropertyName = "api-version")]
+        public string ApiVersion { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty(PropertyName = "metadata")]
+        public List<Metadata> Metadata { get; set; }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/Resource/JwtBearerMiddlewareDiagnostics.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/Resource/JwtBearerMiddlewareDiagnostics.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+
+namespace Microsoft.Identity.Client.Extensions.Web.Resource
+{
+    /// <summary>
+    /// Diagnostics for the JwtBearer middleware (used in Web APIs)
+    /// </summary>
+    public class JwtBearerMiddlewareDiagnostics
+    {
+        /// <summary>
+        /// Invoked if exceptions are thrown during request processing. The exceptions will be re-thrown after this event unless suppressed.
+        /// </summary>
+        static Func<AuthenticationFailedContext, Task> s_onAuthenticationFailed;
+
+        /// <summary>
+        /// Invoked when a protocol message is first received.
+        /// </summary>
+        static Func<MessageReceivedContext, Task> s_onMessageReceived;
+
+        /// <summary>
+        /// Invoked after the security token has passed validation and a ClaimsIdentity has been generated.
+        /// </summary>
+        static Func<TokenValidatedContext, Task> s_onTokenValidated;
+
+        /// <summary>
+        /// Invoked before a challenge is sent back to the caller.
+        /// </summary>
+        static Func<JwtBearerChallengeContext, Task> s_onChallenge;
+
+        /// <summary>
+        /// Subscribes to all the JwtBearer events, to help debugging, while
+        /// preserving the previous handlers (which are called)
+        /// </summary>
+        /// <param name="events">Events to subscribe to</param>
+        public static JwtBearerEvents Subscribe(JwtBearerEvents events)
+        {
+            if (events == null)
+            {
+                events = new JwtBearerEvents();
+            }
+
+            s_onAuthenticationFailed = events.OnAuthenticationFailed;
+            events.OnAuthenticationFailed = OnAuthenticationFailedAsync;
+
+            s_onMessageReceived = events.OnMessageReceived;
+            events.OnMessageReceived = OnMessageReceivedAsync;
+
+            s_onTokenValidated = events.OnTokenValidated;
+            events.OnTokenValidated = OnTokenValidatedAsync;
+
+            s_onChallenge = events.OnChallenge;
+            events.OnChallenge = OnChallengeAsync;
+
+            return events;
+        }
+
+        static async Task OnMessageReceivedAsync(MessageReceivedContext context)
+        {
+            Debug.WriteLine($"1. Begin {nameof(OnMessageReceivedAsync)}");
+            // Place a breakpoint here and examine the bearer token (context.Request.Headers.HeaderAuthorization / context.Request.Headers["Authorization"])
+            // Use https://jwt.ms to decode the token and observe claims
+            await s_onMessageReceived(context).ConfigureAwait(false);
+            Debug.WriteLine($"1. End - {nameof(OnMessageReceivedAsync)}");
+        }
+
+        static async Task OnAuthenticationFailedAsync(AuthenticationFailedContext context)
+        {
+            Debug.WriteLine($"99. Begin {nameof(OnAuthenticationFailedAsync)}");
+            // Place a breakpoint here and examine context.Exception
+            await s_onAuthenticationFailed(context).ConfigureAwait(false);
+            Debug.WriteLine($"99. End - {nameof(OnAuthenticationFailedAsync)}");
+        }
+
+        static async Task OnTokenValidatedAsync(TokenValidatedContext context)
+        {
+            Debug.WriteLine($"2. Begin {nameof(OnTokenValidatedAsync)}");
+            await s_onTokenValidated(context).ConfigureAwait(false);
+            Debug.WriteLine($"2. End - {nameof(OnTokenValidatedAsync)}");
+        }
+
+        static async Task OnChallengeAsync(JwtBearerChallengeContext context)
+        {
+            Debug.WriteLine($"55. Begin {nameof(OnChallengeAsync)}");
+            await s_onChallenge(context).ConfigureAwait(false);
+            Debug.WriteLine($"55. End - {nameof(OnChallengeAsync)}");
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/Resource/Metadata.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/Resource/Metadata.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.Identity.Client.Extensions.Web.Resource
+{
+    /// <summary>
+    /// Model child class to hold alias information parsed from the Azure AD issuer endpoint.
+    /// </summary>
+    public class Metadata
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty(PropertyName = "preferred_network")]
+        public string PreferredNetwork { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty(PropertyName = "preferred_cache")]
+        public string PreferredCache { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [JsonProperty(PropertyName = "aliases")]
+        public List<string> Aliases { get; set; }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/Resource/OpenIdConnectMiddlewareDiagnostics.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/Resource/OpenIdConnectMiddlewareDiagnostics.cs
@@ -1,0 +1,202 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace Microsoft.Identity.Client.Extensions.Web.Resource
+{
+    /// <summary>
+    /// Diagnostics used in the Open Id Connect middleware
+    /// (used in Web Apps)
+    /// </summary>
+    public class OpenIdConnectMiddlewareDiagnostics
+    {
+        //
+        // Summary:
+        //     Invoked before redirecting to the identity provider to authenticate. This can
+        //     be used to set ProtocolMessage.State that will be persisted through the authentication
+        //     process. The ProtocolMessage can also be used to add or customize parameters
+        //     sent to the identity provider.
+        private static Func<RedirectContext, Task> s_onRedirectToIdentityProvider;
+
+        //
+        // Summary:
+        //     Invoked when a protocol message is first received.
+        private static Func<MessageReceivedContext, Task> s_onMessageReceived;
+
+        //
+        // Summary:
+        //     Invoked after security token validation if an authorization code is present in
+        //     the protocol message.
+        private static Func<AuthorizationCodeReceivedContext, Task> s_onAuthorizationCodeReceived;
+
+        //
+        // Summary:
+        //     Invoked after "authorization code" is redeemed for tokens at the token endpoint.
+        private static Func<TokenResponseReceivedContext, Task> s_onTokenResponseReceived;
+
+        //
+        // Summary:
+        //     Invoked when an IdToken has been validated and produced an AuthenticationTicket.
+        private static Func<TokenValidatedContext, Task> s_onTokenValidated;
+
+        //
+        // Summary:
+        //     Invoked when user information is retrieved from the UserInfoEndpoint.
+        private static Func<UserInformationReceivedContext, Task> s_onUserInformationReceived;
+
+        //
+        // Summary:
+        //     Invoked if exceptions are thrown during request processing. The exceptions will
+        //     be re-thrown after this event unless suppressed.
+        private static Func<AuthenticationFailedContext, Task> s_onAuthenticationFailed;
+
+        //
+        // Summary:
+        //     Invoked when a request is received on the RemoteSignOutPath.
+        private static Func<RemoteSignOutContext, Task> s_onRemoteSignOut;
+
+        //
+        // Summary:
+        //     Invoked before redirecting to the identity provider to sign out.
+        private static Func<RedirectContext, Task> s_onRedirectToIdentityProviderForSignOut;
+
+        //
+        // Summary:
+        //     Invoked before redirecting to the Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.SignedOutRedirectUri
+        //     at the end of a remote sign-out flow.
+        private static Func<RemoteSignOutContext, Task> s_onSignedOutCallbackRedirect;
+
+
+        /// <summary>
+        /// Subscribes to all the OpenIdConnect events, to help debugging, while
+        /// preserving the previous handlers (which are called)
+        /// </summary>
+        /// <param name="events">Events to subscribe to</param>
+        public static void Subscribe(OpenIdConnectEvents events)
+        {
+            s_onRedirectToIdentityProvider = events.OnRedirectToIdentityProvider;
+            events.OnRedirectToIdentityProvider = OnRedirectToIdentityProviderAsync;
+
+            s_onMessageReceived = events.OnMessageReceived;
+            events.OnMessageReceived = OnMessageReceivedAsync;
+
+            s_onAuthorizationCodeReceived = events.OnAuthorizationCodeReceived;
+            events.OnAuthorizationCodeReceived = OnAuthorizationCodeReceivedAsync;
+
+            s_onTokenResponseReceived = events.OnTokenResponseReceived;
+            events.OnTokenResponseReceived = OnTokenResponseReceivedAsync;
+
+            s_onTokenValidated = events.OnTokenValidated;
+            events.OnTokenValidated = OnTokenValidatedAsync;
+
+            s_onUserInformationReceived = events.OnUserInformationReceived;
+            events.OnUserInformationReceived = OnUserInformationReceivedAsync;
+
+            s_onAuthenticationFailed = events.OnAuthenticationFailed;
+            events.OnAuthenticationFailed = OnAuthenticationFailedAsync;
+
+            s_onRemoteSignOut = events.OnRemoteSignOut;
+            events.OnRemoteSignOut = OnRemoteSignOutAsync;
+
+            s_onRedirectToIdentityProviderForSignOut = events.OnRedirectToIdentityProviderForSignOut;
+            events.OnRedirectToIdentityProviderForSignOut = OnRedirectToIdentityProviderForSignOutAsync;
+
+            s_onSignedOutCallbackRedirect = events.OnSignedOutCallbackRedirect;
+            events.OnSignedOutCallbackRedirect = OnSignedOutCallbackRedirectAsync;
+        }
+
+        private static async Task OnRedirectToIdentityProviderAsync(RedirectContext context)
+        {
+            Debug.WriteLine($"1. Begin {nameof(OnRedirectToIdentityProviderAsync)}");
+
+            await s_onRedirectToIdentityProvider(context).ConfigureAwait(false);
+
+            Debug.WriteLine("   Sending OpenIdConnect message:");
+            DisplayProtocolMessage(context.ProtocolMessage);
+            Debug.WriteLine($"1. End - {nameof(OnRedirectToIdentityProviderAsync)}");
+        }
+
+        private static void DisplayProtocolMessage(OpenIdConnectMessage message)
+        {
+            foreach (var property in message.GetType().GetProperties())
+            {
+                object value = property.GetValue(message);
+                if (value != null)
+                {
+                    Debug.WriteLine($"   - {property.Name}={value}");
+                }
+            }
+        }
+
+        private static async Task OnMessageReceivedAsync(MessageReceivedContext context)
+        {
+            Debug.WriteLine($"2. Begin {nameof(OnMessageReceivedAsync)}");
+            Debug.WriteLine("   Received from STS the OpenIdConnect message:");
+            DisplayProtocolMessage(context.ProtocolMessage);
+            await s_onMessageReceived(context).ConfigureAwait(false);
+            Debug.WriteLine($"2. End - {nameof(OnMessageReceivedAsync)}");
+        }
+
+        private static async Task OnAuthorizationCodeReceivedAsync(AuthorizationCodeReceivedContext context)
+        {
+            Debug.WriteLine($"4. Begin {nameof(OnAuthorizationCodeReceivedAsync)}");
+            await s_onAuthorizationCodeReceived(context).ConfigureAwait(false);
+            Debug.WriteLine($"4. End - {nameof(OnAuthorizationCodeReceivedAsync)}");
+        }
+
+        private static async Task OnTokenResponseReceivedAsync(TokenResponseReceivedContext context)
+        {
+            Debug.WriteLine($"5. Begin {nameof(OnTokenResponseReceivedAsync)}");
+            await s_onTokenResponseReceived(context).ConfigureAwait(false);
+            Debug.WriteLine($"5. End - {nameof(OnTokenResponseReceivedAsync)}");
+
+        }
+
+        private static async Task OnTokenValidatedAsync(TokenValidatedContext context)
+        {
+            Debug.WriteLine($"3. Begin {nameof(OnTokenValidatedAsync)}");
+            await s_onTokenValidated(context).ConfigureAwait(false);
+            Debug.WriteLine($"3. End - {nameof(OnTokenValidatedAsync)}");
+        }
+
+        private static async Task OnUserInformationReceivedAsync(UserInformationReceivedContext context)
+        {
+            Debug.WriteLine($"6. Begin {nameof(OnUserInformationReceivedAsync)}");
+            await s_onUserInformationReceived(context).ConfigureAwait(false);
+            Debug.WriteLine($"6. End - {nameof(OnUserInformationReceivedAsync)}");
+        }
+
+        private static async Task OnAuthenticationFailedAsync(AuthenticationFailedContext context)
+        {
+            Debug.WriteLine($"99. Begin {nameof(OnAuthenticationFailedAsync)}");
+            await s_onAuthenticationFailed(context).ConfigureAwait(false);
+            Debug.WriteLine($"99. End - {nameof(OnAuthenticationFailedAsync)}");
+        }
+
+        private static async Task OnRedirectToIdentityProviderForSignOutAsync(RedirectContext context)
+        {
+            Debug.WriteLine($"10. Begin {nameof(OnRedirectToIdentityProviderForSignOutAsync)}");
+            await s_onRedirectToIdentityProviderForSignOut(context).ConfigureAwait(false);
+            Debug.WriteLine($"10. End - {nameof(OnRedirectToIdentityProviderForSignOutAsync)}");
+        }
+
+        private static async Task OnRemoteSignOutAsync(RemoteSignOutContext context)
+        {
+            Debug.WriteLine($"11. Begin {nameof(OnRemoteSignOutAsync)}");
+            await s_onRemoteSignOut(context).ConfigureAwait(false);
+            Debug.WriteLine($"11. End - {nameof(OnRemoteSignOutAsync)}");
+        }
+
+        private static async Task OnSignedOutCallbackRedirectAsync(RemoteSignOutContext context)
+        {
+            Debug.WriteLine($"12. Begin {nameof(OnSignedOutCallbackRedirectAsync)}");
+            await s_onSignedOutCallbackRedirect(context).ConfigureAwait(false);
+            Debug.WriteLine($"12. End {nameof(OnSignedOutCallbackRedirectAsync)}");
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/ServiceCollectionExtensions.cs
@@ -1,0 +1,274 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Identity.Client.Extensions.Web.Resource;
+using Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace Microsoft.Identity.Client.Extensions.Web
+{
+    /// <summary>
+    /// Extensions for IServiceCollection for startup initialization.
+    /// </summary>
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Add authentication with Microsoft identity platform v2.0 (AAD v2.0).
+        /// This supposes that the configuration files have a section named "AzureAD"
+        /// </summary>
+        /// <param name="services">Service collection to which to add authentication</param>
+        /// <param name="configuration">Configuration</param>
+        /// <param name="subscribeToOpenIdConnectMiddlewareDiagnosticsEvents">
+        /// Set to true if you want to debug, or just understand the OpenIdConnect events.
+        /// </param>
+        /// <returns></returns>
+        public static IServiceCollection AddAzureAdV2Authentication(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            bool subscribeToOpenIdConnectMiddlewareDiagnosticsEvents = false)
+        {
+            services.AddAuthentication(AzureADDefaults.AuthenticationScheme)
+                .AddAzureAD(options => configuration.Bind("AzureAd", options));
+
+            services.Configure<OpenIdConnectOptions>(AzureADDefaults.OpenIdScheme, options =>
+            {
+                // Per the code below, this application signs in users in any Work and School
+                // accounts and any Microsoft Personal Accounts.
+                // If you want to direct Azure AD to restrict the users that can sign-in, change 
+                // the tenant value of the appsettings.json file in the following way:
+                // - only Work and School accounts => 'organizations'
+                // - only Microsoft Personal accounts => 'consumers'
+                // - Work and School and Personal accounts => 'common'
+                // If you want to restrict the users that can sign-in to only one tenant
+                // set the tenant value in the appsettings.json file to the tenant ID 
+                // or domain of this organization
+                options.Authority = options.Authority + "/v2.0/";
+
+                // If you want to restrict the users that can sign-in to several organizations
+                // Set the tenant value in the appsettings.json file to 'organizations', and add the
+                // issuers you want to accept to options.TokenValidationParameters.ValidIssuers collection
+                options.TokenValidationParameters.IssuerValidator = AadIssuerValidator.ForAadInstance(options.Authority).ValidateAadIssuer;
+
+                // Set the nameClaimType to be preferred_username.
+                // This change is needed because certain token claims from Azure AD V1 endpoint 
+                // (on which the original .NET core template is based) are different than Azure AD V2 endpoint. 
+                // For more details see [ID Tokens](https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens) 
+                // and [Access Tokens](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens)
+                options.TokenValidationParameters.NameClaimType = "preferred_username";
+
+                // Handling the sign-out: removing the account from MSAL.NET cache
+                options.Events.OnRedirectToIdentityProviderForSignOut = context =>
+                {
+                    var user = context.HttpContext.User;
+
+                    // Avoid displaying the select account dialog
+                    context.ProtocolMessage.LoginHint = user.GetLoginHint();
+                    context.ProtocolMessage.DomainHint = user.GetDomainHint();
+                    return Task.FromResult(0);
+                };
+
+                // Avoids having users being presented the select account dialog when they are already signed-in
+                // for instance when going through incremental consent 
+                options.Events.OnRedirectToIdentityProvider = context =>
+                {
+                    var login = context.Properties.GetParameter<string>(OpenIdConnectParameterNames.LoginHint);
+                    if (!string.IsNullOrWhiteSpace(login))
+                    {
+                        context.ProtocolMessage.LoginHint = login;
+                        context.ProtocolMessage.DomainHint = context.Properties.GetParameter<string>(
+                            OpenIdConnectParameterNames.DomainHint);
+
+                        // delete the loginhint and domainHint from the Properties when we are done otherwise 
+                        // it will take up extra space in the cookie.
+                        context.Properties.Parameters.Remove(OpenIdConnectParameterNames.LoginHint);
+                        context.Properties.Parameters.Remove(OpenIdConnectParameterNames.DomainHint);
+                    }
+
+                    // Additional claims
+                    if (context.Properties.Items.ContainsKey(OidcConstants.AdditionalClaims))
+                    {
+                        context.ProtocolMessage.SetParameter(
+                            OidcConstants.AdditionalClaims,
+                            context.Properties.Items[OidcConstants.AdditionalClaims]);
+                    }
+
+                    return Task.FromResult(0);
+                };
+
+                if (subscribeToOpenIdConnectMiddlewareDiagnosticsEvents)
+                {
+                    OpenIdConnectMiddlewareDiagnostics.Subscribe(options.Events);
+                }
+            });
+            return services;
+        }
+
+        /// <summary>
+        /// Add MSAL support to the Web App or Web API
+        /// </summary>
+        /// <param name="services">Service collection to which to add authentication</param>
+        /// <param name="initialScopes">Initial scopes to request at sign-in</param>
+        /// <returns></returns>
+        public static IServiceCollection AddMsal(this IServiceCollection services, IEnumerable<string> initialScopes)
+        {
+            services.AddTokenAcquisition();
+
+            services.Configure<OpenIdConnectOptions>(AzureADDefaults.OpenIdScheme, options =>
+            {
+                // Response type
+                options.ResponseType = OpenIdConnectResponseType.CodeIdToken;
+
+                // This scope is needed to get a refresh token when users sign-in with their Microsoft personal accounts
+                // (it's required by MSAL.NET and automatically provided when users sign-in with work or school accounts)
+                options.Scope.Add(OidcConstants.ScopeOfflineAccess);
+                if (initialScopes != null)
+                {
+                    foreach (string scope in initialScopes)
+                    {
+                        if (!options.Scope.Contains(scope))
+                        {
+                            options.Scope.Add(scope);
+                        }
+                    }
+                }
+
+                // Handling the auth redemption by MSAL.NET so that a token is available in the token cache
+                // where it will be usable from Controllers later (through the TokenAcquisition service)
+                var handler = options.Events.OnAuthorizationCodeReceived;
+                options.Events.OnAuthorizationCodeReceived = async context =>
+                {
+                    var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>();
+                    await tokenAcquisition.AddAccountToCacheFromAuthorizationCodeAsync(context, options.Scope).ConfigureAwait(false);
+                    await handler(context).ConfigureAwait(false);
+                };
+
+                // Handling the sign-out: removing the account from MSAL.NET cache
+                options.Events.OnRedirectToIdentityProviderForSignOut = async context =>
+                {
+                    // Remove the account from MSAL.NET token cache
+                    var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>();
+                    await tokenAcquisition.RemoveAccountAsync(context).ConfigureAwait(false);
+                };
+            });
+            return services;
+        }
+
+        /// <summary>
+        /// Protects the Web API with Microsoft Identity Platform v2.0 (AAD v2.0)
+        /// This supposes that the configuration files have a section named "AzureAD"
+        /// </summary>
+        /// <param name="services">Service collection to which to add authentication</param>
+        /// <param name="configuration">Configuration</param>
+        /// <param name="subscribeToJwtBearerMiddlewareDiagnosticsEvents">
+        /// Set to true if you want to debug, or just understand the JwtBearer events.
+        /// </param>
+        /// <returns></returns>
+        public static IServiceCollection AddProtectWebApiWithMicrosoftIdentityPlatformV2(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            bool subscribeToJwtBearerMiddlewareDiagnosticsEvents = false)
+        {
+            services.AddAuthentication(AzureADDefaults.JwtBearerAuthenticationScheme)
+                    .AddAzureADBearer(options => configuration.Bind("AzureAd", options));
+
+            services.AddSession();
+
+            // Added
+            services.Configure<JwtBearerOptions>(AzureADDefaults.JwtBearerAuthenticationScheme, options =>
+            {
+                // This is an Azure AD v2.0 Web API
+                options.Authority += "/v2.0";
+
+                // The valid audiences are both the Client ID (options.Audience) and api://{ClientID}
+                options.TokenValidationParameters.ValidAudiences = new string[]
+                {
+                    options.Audience, $"api://{options.Audience}"
+                };
+
+                // Instead of using the default validation (validating against a single tenant, as we do in line of business apps),
+                // we inject our own multitenant validation logic (which even accepts both V1 and V2 tokens)
+                options.TokenValidationParameters.IssuerValidator = AadIssuerValidator.ForAadInstance(options.Authority).ValidateAadIssuer;
+
+                // When an access token for our own Web API is validated, we add it to MSAL.NET's cache so that it can
+                // be used from the controllers.
+                options.Events = new JwtBearerEvents();
+
+                if (subscribeToJwtBearerMiddlewareDiagnosticsEvents)
+                {
+                    options.Events = JwtBearerMiddlewareDiagnostics.Subscribe(options.Events);
+                }
+            });
+
+            return services;
+        }
+
+        /// <summary>
+        /// Protects the Web API with Microsoft Identity Platform v2.0 (AAD v2.0)
+        /// This supposes that the configuration files have a section named "AzureAD"
+        /// </summary>
+        /// <param name="services">Service collection to which to add authentication</param>
+        /// <param name="configuration">Configuration</param>
+        /// <param name="scopes"></param>
+        /// <returns></returns>
+        public static IServiceCollection AddProtectedApiCallsWebApis(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            IEnumerable<string> scopes)
+        {
+            services.AddTokenAcquisition();
+            services.Configure<JwtBearerOptions>(AzureADDefaults.JwtBearerAuthenticationScheme, options =>
+            {
+                options.Events.OnTokenValidated = async context =>
+                {
+                    var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService<ITokenAcquisition>();
+                    context.Success();
+
+                    // Adds the token to the cache, and also handles the incremental consent and claim challenges
+                    await tokenAcquisition.AddAccountToCacheFromJwtAsync(context, scopes).ConfigureAwait(false);
+                };
+            });
+            return services;
+        }
+
+        /// <summary>
+        /// Add the token acquisition service.
+        /// </summary>
+        /// <param name="services">Service collection</param>
+        /// <returns>the service collection</returns>
+        /// <example>
+        /// This method is typically called from the Startup.ConfigureServices(IServiceCollection services)
+        /// Note that the implementation of the token cache can be chosen separately.
+        ///
+        /// <code>
+        /// // Token acquisition service and its cache implementation as a session cache
+        /// services.AddTokenAcquisition()
+        /// .AddDistributedMemoryCache()
+        /// .AddSession()
+        /// .AddSessionBasedTokenCache()
+        ///  ;
+        /// </code>
+        /// </example>
+        public static IServiceCollection AddTokenAcquisition(this IServiceCollection services)
+        {
+            // Token acquisition service
+            services.AddScoped<ITokenAcquisition>(factory =>
+            {
+                var config = factory.GetRequiredService<IConfiguration>();
+                var apptokencacheprovider = factory.GetService<IMsalAppTokenCacheProvider>();
+                var usertokencacheprovider = factory.GetService<IMsalUserTokenCacheProvider>();
+
+                return new TokenAcquisition(config, apptokencacheprovider, usertokencacheprovider);
+            });
+
+            return services;
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/TokenAcquisition.cs
@@ -15,7 +15,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;
-using Microsoft.Identity.Client.AppConfig;
 using Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders;
 using Microsoft.Net.Http.Headers;
 
@@ -436,7 +435,7 @@ namespace Microsoft.Identity.Client.Extensions.Web
         {
             // A user interaction is required, but we are in a Web API, and therefore, we need to report back to the client through an wwww-Authenticate header https://tools.ietf.org/html/rfc6750#section-3.1
             string proposedAction = "consent";
-            if (msalSeviceException.ErrorCode == MsalUiRequiredException.InvalidGrantError)
+            if (msalSeviceException.ErrorCode == MsalError.InvalidGrantError)
             {
                 if (AcceptedTokenVersionIsNotTheSameAsTokenVersion(msalSeviceException))
                 {

--- a/src/Microsoft.Identity.Client.Extensions.Web/TokenAcquisition.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/TokenAcquisition.cs
@@ -1,0 +1,479 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Net;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Identity.Client.AppConfig;
+using Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders;
+using Microsoft.Net.Http.Headers;
+
+namespace Microsoft.Identity.Client.Extensions.Web
+{
+    /// <summary>
+    /// Token acquisition service
+    /// </summary>
+    public class TokenAcquisition : ITokenAcquisition
+    {
+        private readonly AzureADOptions _azureAdOptions;
+        private readonly ConfidentialClientApplicationOptions _applicationOptions;
+
+        private readonly IMsalAppTokenCacheProvider _appTokenCacheProvider;
+        private readonly IMsalUserTokenCacheProvider _userTokenCacheProvider;
+
+        /// <summary>
+        /// Constructor of the TokenAcquisition service. This requires the Azure AD Options to
+        /// configure the confidential client application and a token cache provider.
+        /// This constructor is called by ASP.NET Core dependency injection
+        /// </summary>
+        /// <param name="appTokenCacheProvider">The App token cache provider</param>
+        /// <param name="userTokenCacheProvider">The User token cache provider</param>
+        /// <param name="configuration"></param>
+        public TokenAcquisition(
+            IConfiguration configuration,
+            IMsalAppTokenCacheProvider appTokenCacheProvider,
+            IMsalUserTokenCacheProvider userTokenCacheProvider)
+        {
+            _azureAdOptions = new AzureADOptions();
+            configuration.Bind("AzureAD", _azureAdOptions);
+
+            _applicationOptions = new ConfidentialClientApplicationOptions();
+            configuration.Bind("AzureAD", _applicationOptions);
+
+            _appTokenCacheProvider = appTokenCacheProvider;
+            _userTokenCacheProvider = userTokenCacheProvider;
+        }
+
+        /// <summary>
+        /// Scopes which are already requested by MSAL.NET. they should not be re-requested;
+        /// </summary>
+        private readonly string[] _scopesRequestedByMsalNet = new string[]
+        {
+            OidcConstants.ScopeOpenId,
+            OidcConstants.ScopeProfile,
+            OidcConstants.ScopeOfflineAccess
+        };
+
+        /// <summary>
+        /// In a Web App, adds, to the MSAL.NET cache, the account of the user authenticating to the Web App, when the authorization code is received (after the user
+        /// signed-in and consented)
+        /// An On-behalf-of token contained in the <see cref="AuthorizationCodeReceivedContext"/> is added to the cache, so that it can then be used to acquire another token on-behalf-of the
+        /// same user in order to call to downstream APIs.
+        /// </summary>
+        /// <param name="context">The context used when an 'AuthorizationCode' is received over the OpenIdConnect protocol.</param>
+        /// <param name="scopes"></param>
+        /// <example>
+        /// From the configuration of the Authentication of the ASP.NET Core Web API:
+        /// <code>OpenIdConnectOptions options;</code>
+        ///
+        /// Subscribe to the authorization code recieved event:
+        /// <code>
+        ///  options.Events = new OpenIdConnectEvents();
+        ///  options.Events.OnAuthorizationCodeReceived = OnAuthorizationCodeReceived;
+        /// }
+        /// </code>
+        ///
+        /// And then in the OnAuthorizationCodeRecieved method, call <see cref="AddAccountToCacheFromAuthorizationCodeAsync"/>:
+        /// <code>
+        /// private async Task OnAuthorizationCodeReceived(AuthorizationCodeReceivedContext context)
+        /// {
+        ///   var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService&lt;ITokenAcquisition&gt;();
+        ///    await _tokenAcquisition.AddAccountToCacheFromAuthorizationCode(context, new string[] { "user.read" });
+        /// }
+        /// </code>
+        /// </example>
+        public async Task AddAccountToCacheFromAuthorizationCodeAsync(AuthorizationCodeReceivedContext context, IEnumerable<string> scopes)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (scopes == null)
+            {
+                throw new ArgumentNullException(nameof(scopes));
+            }
+
+            try
+            {
+                // As AcquireTokenByAuthorizationCodeAsync is asynchronous we want to tell ASP.NET core that we are handing the code
+                // even if it's not done yet, so that it does not concurrently call the Token endpoint.
+                context.HandleCodeRedemption();
+
+                var application = BuildConfidentialClientApplication(context.HttpContext, context.Principal);
+
+                // Do not share the access token with ASP.NET Core otherwise ASP.NET will cache it and will not send the OAuth 2.0 request in
+                // case a further call to AcquireTokenByAuthorizationCodeAsync in the future for incremental consent (getting a code requesting more scopes)
+                // Share the ID Token
+                var result = await application
+                    .AcquireTokenByAuthorizationCode(scopes.Except(_scopesRequestedByMsalNet), context.ProtocolMessage.Code)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                context.HandleCodeRedemption(null, result.IdToken);
+            }
+            catch (MsalException ex)
+            {
+                Debug.WriteLine(ex.Message);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Typically used from an ASP.NET Core Web App or Web API controller, this method gets an access token
+        /// for a downstream API on behalf of the user account which claims are provided in the <see cref="HttpContext.User"/>
+        /// member of the <paramref name="context"/> parameter
+        /// </summary>
+        /// <param name="context">HttpContext associated with the Controller or auth operation</param>
+        /// <param name="scopes">Scopes to request for the downstream API to call</param>
+        /// <param name="tenant">Enables to override the tenant/account for the same identity. This is useful in the
+        /// cases where a given account is guest in other tenants, and you want to acquire tokens for a specific tenant</param>
+        /// <returns>An access token to call on behalf of the user, the downstream API characterized by its scopes</returns>
+        public async Task<string> GetAccessTokenOnBehalfOfUserAsync(
+            HttpContext context,
+            IEnumerable<string> scopes,
+            string tenant = null)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (scopes == null)
+            {
+                throw new ArgumentNullException(nameof(scopes));
+            }
+
+            // Use MSAL to get the right token to call the API
+            var application = BuildConfidentialClientApplication(context, context.User);
+            return await GetAccessTokenOnBehalfOfUserAsync(application, context.User, scopes, tenant).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// In a Web API, adds to the MSAL.NET cache, the account of the user for which a bearer token was received when the Web API was called.
+        /// An access token and a refresh token are added to the cache, so that they can then be used to acquire another token on-behalf-of the
+        /// same user in order to call to downstream APIs.
+        /// </summary>
+        /// <param name="tokenValidatedContext">Token validation context passed to the handler of the OnTokenValidated event
+        /// for the JwtBearer middleware</param>
+        /// <param name="scopes">[Optional] scopes to pre-request for a downstream API</param>
+        /// <example>
+        /// From the configuration of the Authentication of the ASP.NET Core Web API (for example in the Startup.cs file)
+        /// <code>JwtBearerOptions option;</code>
+        ///
+        /// Subscribe to the token validated event:
+        /// <code>
+        /// options.Events = new JwtBearerEvents();
+        /// options.Events.OnTokenValidated = async context =>
+        /// {
+        ///   var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService&lt;ITokenAcquisition&gt;();
+        ///   tokenAcquisition.AddAccountToCacheFromJwt(context);
+        /// };
+        /// </code>
+        /// </example>
+        public Task AddAccountToCacheFromJwtAsync(
+            Microsoft.AspNetCore.Authentication.JwtBearer.TokenValidatedContext tokenValidatedContext,
+            IEnumerable<string> scopes)
+        {
+            if (tokenValidatedContext == null)
+            {
+                throw new ArgumentNullException(nameof(tokenValidatedContext));
+            }
+
+            return AddAccountToCacheFromJwtAsync(
+                scopes,
+                tokenValidatedContext.SecurityToken as JwtSecurityToken,
+                tokenValidatedContext.Principal,
+                tokenValidatedContext.HttpContext);
+        }
+
+        /// <summary>
+        /// [not recommended] In a Web App, adds, to the MSAL.NET cache, the account of the user authenticating to the Web App.
+        /// An On-behalf-of token is added to the cache, so that it can then be used to acquire another token on-behalf-of the
+        /// same user in order for the Web App to call a Web APIs.
+        /// </summary>
+        /// <param name="tokenValidatedContext">Token validation context passed to the handler of the OnTokenValidated event
+        /// for the OpenIdConnect middleware</param>
+        /// <param name="scopes">[Optional] scopes to pre-request for a downstream API</param>
+        /// <remarks>In a Web App, it's preferable to not request an access token, but only a code, and use the <see cref="AddAccountToCacheFromAuthorizationCodeAsync"/></remarks>
+        /// <example>
+        /// From the configuration of the Authentication of the ASP.NET Core Web API:
+        /// <code>OpenIdConnectOptions options;</code>
+        ///
+        /// Subscribe to the token validated event:
+        /// <code>
+        ///  options.Events.OnAuthorizationCodeReceived = OnTokenValidated;
+        /// </code>
+        ///
+        /// And then in the OnTokenValidated method, call <see cref="AddAccountToCacheFromJwtAsync(TokenValidatedContext, IEnumerable&lt;string&gt;)"/>:
+        /// <code>
+        /// private async Task OnTokenValidated(TokenValidatedContext context)
+        /// {
+        ///   var tokenAcquisition = context.HttpContext.RequestServices.GetRequiredService&lt;ITokenAcquisition&gt;();
+        ///  _tokenAcquisition.AddAccountToCache(tokenValidationContext);
+        /// }
+        /// </code>
+        /// </example>
+        public Task AddAccountToCacheFromJwtAsync(
+            TokenValidatedContext tokenValidatedContext,
+            IEnumerable<string> scopes = null)
+        {
+            if (tokenValidatedContext == null)
+            {
+                throw new ArgumentNullException(nameof(tokenValidatedContext));
+            }
+
+            return AddAccountToCacheFromJwtAsync(
+                scopes,
+                tokenValidatedContext.SecurityToken,
+                tokenValidatedContext.Principal,
+                tokenValidatedContext.HttpContext);
+        }
+
+        /// <summary>
+        /// Removes the account associated with context.HttpContext.User from the MSAL.NET cache
+        /// </summary>
+        /// <param name="context">RedirectContext passed-in to a Openidconnect event</param>
+        /// <returns></returns>
+        public async Task RemoveAccountAsync(RedirectContext context)
+        {
+            ClaimsPrincipal user = context.HttpContext.User;
+            IConfidentialClientApplication app = BuildConfidentialClientApplication(context.HttpContext, user);
+            IAccount account = await app.GetAccountAsync(context.HttpContext.User.GetMsalAccountId()).ConfigureAwait(false);
+
+            // Workaround for the guest account
+            if (account == null)
+            {
+                var accounts = await app.GetAccountsAsync().ConfigureAwait(false);
+                account = accounts.FirstOrDefault(a => a.Username == user.GetLoginHint());
+            }
+
+            // AppTokenCacheProvider?.Clear();
+            _userTokenCacheProvider?.Clear();
+
+            await app.RemoveAsync(account).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates an MSAL Confidential client application
+        /// </summary>
+        /// <param name="httpContext"></param>
+        /// <param name="claimsPrincipal"></param>
+        /// <returns></returns>
+        private IConfidentialClientApplication BuildConfidentialClientApplication(
+            HttpContext httpContext,
+            ClaimsPrincipal claimsPrincipal)
+        {
+            var request = httpContext.Request;
+            string currentUri = UriHelper.BuildAbsolute(
+                request.Scheme,
+                request.Host,
+                request.PathBase,
+                _azureAdOptions.CallbackPath ?? string.Empty);
+
+            string authority = $"{_azureAdOptions.Instance}{_azureAdOptions.TenantId}/";
+
+            var app = ConfidentialClientApplicationBuilder
+                .CreateWithApplicationOptions(_applicationOptions)
+                .WithRedirectUri(currentUri)
+                .WithAuthority(authority)
+                .Build();
+
+            // Initialize token cache providers
+            if (_appTokenCacheProvider != null)
+            {
+                _appTokenCacheProvider.Initialize(app.AppTokenCache, httpContext);
+            }
+
+            if (_userTokenCacheProvider != null)
+            {
+                _userTokenCacheProvider.Initialize(app.UserTokenCache, httpContext, claimsPrincipal);
+            }
+
+            return app;
+        }
+
+        /// <summary>
+        /// Gets an access token for a downstream API on behalf of the user described by its claimsPrincipal
+        /// </summary>
+        /// <param name="application"></param>
+        /// <param name="claimsPrincipal">Claims principal for the user on behalf of whom to get a token</param>
+        /// <param name="scopes">Scopes for the downstream API to call</param>
+        /// <param name="tenant"></param>
+        private async Task<string> GetAccessTokenOnBehalfOfUserAsync(
+            IConfidentialClientApplication application,
+            ClaimsPrincipal claimsPrincipal,
+            IEnumerable<string> scopes,
+            string tenant)
+        {
+            if (tenant == null)
+            {
+                throw new ArgumentNullException(nameof(tenant));
+            }
+
+            string accountIdentifier = claimsPrincipal.GetMsalAccountId();
+            string loginHint = claimsPrincipal.GetLoginHint();
+            return await GetAccessTokenOnBehalfOfUserAsync(application, accountIdentifier, scopes, loginHint, tenant).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets an access token for a downstream API on behalf of the user which account ID is passed as an argument
+        /// </summary>
+        /// <param name="application"></param>
+        /// <param name="accountIdentifier">User account identifier for which to acquire a token.
+        /// See <see cref="Microsoft.Identity.Client.AccountId.Identifier"/></param>
+        /// <param name="scopes">Scopes for the downstream API to call</param>
+        /// <param name="loginHint"></param>
+        /// <param name="tenant"></param>
+        private async Task<string> GetAccessTokenOnBehalfOfUserAsync(
+            IConfidentialClientApplication application,
+            string accountIdentifier,
+            IEnumerable<string> scopes,
+            string loginHint,
+            string tenant)
+        {
+            if (accountIdentifier == null)
+            {
+                throw new ArgumentNullException(nameof(accountIdentifier));
+            }
+
+            if (scopes == null)
+            {
+                throw new ArgumentNullException(nameof(scopes));
+            }
+
+            if (loginHint == null)
+            {
+                throw new ArgumentNullException(nameof(loginHint));
+            }
+
+            // Get the account
+            IAccount account = await application.GetAccountAsync(accountIdentifier).ConfigureAwait(false);
+
+            // Special case for guest users as the Guest iod / tenant id are not surfaced.
+            if (account == null)
+            {
+                var accounts = await application.GetAccountsAsync().ConfigureAwait(false);
+                account = accounts.FirstOrDefault(a => a.Username == loginHint);
+            }
+
+            AuthenticationResult result;
+            if (string.IsNullOrWhiteSpace(tenant))
+            {
+                result = await application
+                    .AcquireTokenSilent(scopes.Except(_scopesRequestedByMsalNet), account)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                string authority = application.Authority.Replace(new Uri(application.Authority).PathAndQuery, $"/{tenant}/");
+                result = await application
+                    .AcquireTokenSilent(scopes.Except(_scopesRequestedByMsalNet), account)
+                    .WithAuthority(authority)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+            }
+            return result.AccessToken;
+        }
+
+        /// <summary>
+        /// Adds an account to the token cache from a JWT token and other parameters related to the token cache implementation
+        /// </summary>
+        private async Task AddAccountToCacheFromJwtAsync(IEnumerable<string> scopes, JwtSecurityToken jwtToken, ClaimsPrincipal principal, HttpContext httpContext)
+        {
+            try
+            {
+                UserAssertion userAssertion;
+                IEnumerable<string> requestedScopes;
+                if (jwtToken != null)
+                {
+                    userAssertion = new UserAssertion(jwtToken.RawData, "urn:ietf:params:oauth:grant-type:jwt-bearer");
+                    requestedScopes = scopes ?? jwtToken.Audiences.Select(a => $"{a}/.default");
+                }
+                else
+                {
+                    throw new ArgumentOutOfRangeException("tokenValidationContext.SecurityToken should be a JWT Token");
+                    // TODO: Understand if we could support other kind of client assertions (SAML);
+                }
+
+                var application = BuildConfidentialClientApplication(httpContext, principal);
+
+                // .Result to make sure that the cache is filled-in before the controller tries to get access tokens
+                var result = await application
+                    .AcquireTokenOnBehalfOf(requestedScopes.Except(_scopesRequestedByMsalNet), userAssertion)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+            }
+            catch (MsalException ex)
+            {
+                Debug.WriteLine(ex.Message);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Used in Web APIs (which therefore cannot have an interaction with the user). 
+        /// Replies to the client through the HttpReponse by sending a 403 (forbidden) and populating wwwAuthenticateHeaders so that
+        /// the client can trigger an iteraction with the user so that the user consents to more scopes
+        /// </summary>
+        /// <param name="httpContext">HttpContext</param>
+        /// <param name="scopes">Scopes to consent to</param>
+        /// <param name="msalSeviceException"><see cref="MsalUiRequiredException"/> triggering the challenge</param>
+
+        public void ReplyForbiddenWithWwwAuthenticateHeader(HttpContext httpContext, IEnumerable<string> scopes, MsalUiRequiredException msalSeviceException)
+        {
+            // A user interaction is required, but we are in a Web API, and therefore, we need to report back to the client through an wwww-Authenticate header https://tools.ietf.org/html/rfc6750#section-3.1
+            string proposedAction = "consent";
+            if (msalSeviceException.ErrorCode == MsalUiRequiredException.InvalidGrantError)
+            {
+                if (AcceptedTokenVersionIsNotTheSameAsTokenVersion(msalSeviceException))
+                {
+                    throw msalSeviceException;
+                }
+            }
+
+            IDictionary<string, string> parameters = new Dictionary<string, string>()
+                {
+                    { "clientId", _azureAdOptions.ClientId },
+                    { "claims", msalSeviceException.Claims },
+                    { "scopes", string.Join(",", scopes) },
+                    { "proposedAction", proposedAction }
+                };
+
+            string parameterString = string.Join(", ", parameters.Select(p => $"{p.Key}=\"{p.Value}\""));
+            string scheme = "Bearer";
+            StringValues v = new StringValues($"{scheme} {parameterString}");
+
+            //  StringValues v = new StringValues(new string[] { $"Bearer clientId=\"{jwtToken.Audiences.First()}\", claims=\"{ex.Claims}\", scopes=\" {string.Join(",", scopes)}\"" });
+            var httpResponse = httpContext.Response;
+            var headers = httpResponse.Headers;
+            httpResponse.StatusCode = (int)HttpStatusCode.Forbidden;
+            if (headers.ContainsKey(HeaderNames.WWWAuthenticate))
+            {
+                headers.Remove(HeaderNames.WWWAuthenticate);
+            }
+            headers.Add(HeaderNames.WWWAuthenticate, v);
+        }
+
+        private static bool AcceptedTokenVersionIsNotTheSameAsTokenVersion(MsalUiRequiredException msalSeviceException)
+        {
+            // Normally app developers should not make decisions based on the internal AAD code
+            // however until the STS sends sub-error codes for this error, this is the only
+            // way to distinguish the case. 
+            // This is subject to change in the future
+            return (msalSeviceException.Message.Contains("AADSTS50013"));
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/IMsalAppTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/IMsalAppTokenCacheProvider.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders
+{
+    /// <summary>
+    /// MSAL token cache provider interface for application cache
+    /// </summary>
+    public interface IMsalAppTokenCacheProvider
+    {
+        /// <summary>Initializes this instance of TokenCacheProvider with essentials to initialize themselves.</summary>
+        /// <param name="tokenCache">The token cache instance of MSAL application</param>
+        /// <param name="httpcontext">The Httpcontext whose Session will be used for caching.This is required by some providers.</param>
+        void Initialize(ITokenCache tokenCache, HttpContext httpcontext);
+
+        /// <summary>
+        /// Clears the token cache for this app
+        /// </summary>
+        void Clear();
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/IMsalUserTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/IMsalUserTokenCacheProvider.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders
+{
+    /// <summary>
+    /// MSAL token cache provider interface for user accounts
+    /// </summary>
+    public interface IMsalUserTokenCacheProvider
+    {
+        /// <summary>Initializes this instance of TokenCacheProvider with essentials to initialize themselves.</summary>
+        /// <param name="tokenCache">The token cache instance of MSAL application</param>
+        /// <param name="httpcontext">The Httpcontext whose Session will be used for caching.This is required by some providers.</param>
+        /// <param name="user">The signed-in user for whom the cache needs to be established. Not needed by all providers.</param>
+        void Initialize(ITokenCache tokenCache, HttpContext httpcontext, ClaimsPrincipal user);
+
+        /// <summary>
+        /// Clears the token cache for this user
+        /// </summary>
+        void Clear();
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/InMemory/InMemoryServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/InMemory/InMemoryServiceCollectionExtensions.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders.InMemory
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public static class InMemoryServiceCollectionExtensions
+    {
+        /// <summary>Adds both the app and per-user in-memory token caches.</summary>
+        /// <param name="services">The services collection to add to.</param>
+        /// <param name="cacheOptions">the MSALMemoryTokenCacheOptions allows the caller to set the token cache expiration</param>
+        /// <returns></returns>
+        public static IServiceCollection AddInMemoryTokenCaches(
+            this IServiceCollection services,
+            MsalMemoryTokenCacheOptions cacheOptions = null)
+        {
+            var memoryCacheoptions = (cacheOptions == null)
+                ? new MsalMemoryTokenCacheOptions
+                    {
+                        AbsoluteExpiration = DateTimeOffset.Now.AddDays(14)
+                    }
+                : cacheOptions;
+
+            AddInMemoryAppTokenCache(services, memoryCacheoptions);
+            AddInMemoryPerUserTokenCache(services, memoryCacheoptions);
+            return services;
+        }
+
+
+        /// <summary>Adds the in-memory based application token cache to the service collection.</summary>
+        /// <param name="services">The services collection to add to.</param>
+        /// <param name="cacheOptions">the MSALMemoryTokenCacheOptions allows the caller to set the token cache expiration</param>
+        public static IServiceCollection AddInMemoryAppTokenCache(
+            this IServiceCollection services,
+            MsalMemoryTokenCacheOptions cacheOptions)
+        {
+            services.AddMemoryCache();
+
+            services.AddSingleton<IMsalAppTokenCacheProvider>(factory =>
+            {
+                var memoryCache = factory.GetRequiredService<IMemoryCache>();
+                var optionsMonitor = factory.GetRequiredService<IOptionsMonitor<AzureADOptions>>();
+
+                return new MsalAppMemoryTokenCacheProvider(memoryCache, cacheOptions, optionsMonitor);
+            });
+
+            return services;
+        }
+
+        /// <summary>Adds the in-memory based per user token cache to the service collection.</summary>
+        /// <param name="services">The services collection to add to.</param>
+        /// <param name="cacheOptions">the MSALMemoryTokenCacheOptions allows the caller to set the token cache expiration</param>
+        /// <returns></returns>
+        public static IServiceCollection AddInMemoryPerUserTokenCache(
+            this IServiceCollection services,
+            MsalMemoryTokenCacheOptions cacheOptions)
+        {
+            services.AddMemoryCache();
+
+            services.AddSingleton<IMsalUserTokenCacheProvider>(factory =>
+            {
+                var memoryCache = factory.GetRequiredService<IMemoryCache>();
+                return new MsalPerUserMemoryTokenCacheProvider(memoryCache, cacheOptions);
+            });
+
+            return services;
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/InMemory/MsalAppMemoryTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/InMemory/MsalAppMemoryTokenCacheProvider.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders.InMemory
+{
+    /// <summary>
+    /// An implementation of token cache for Confidential clients backed by MemoryCache.
+    /// MemoryCache is useful in Api scenarios where there is no HttpContext to cache data.
+    /// </summary>
+    /// <remarks>https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/token-cache-serialization</remarks>
+    public class MsalAppMemoryTokenCacheProvider : IMsalAppTokenCacheProvider
+    {
+        /// <summary>
+        /// The application cache key
+        /// </summary>
+        internal string _appCacheId;
+
+        /// <summary>
+        /// The backing MemoryCache instance
+        /// </summary>
+        internal IMemoryCache _memoryCache;
+
+        /// <summary>
+        /// The internal handle to the client's instance of the Cache
+        /// </summary>
+        private ITokenCache _apptokenCache;
+
+        private readonly MsalMemoryTokenCacheOptions _cacheOptions;
+
+        /// <summary>
+        /// The App's whose cache we are maintaining.
+        /// </summary>
+        private readonly string _appId;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public ITokenCache ApptokenCache { get => _apptokenCache; set => _apptokenCache = value; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="cache"></param>
+        /// <param name="option"></param>
+        /// <param name="azureAdOptionsAccessor"></param>
+        public MsalAppMemoryTokenCacheProvider(IMemoryCache cache,
+            MsalMemoryTokenCacheOptions option,
+            IOptionsMonitor<AzureADOptions> azureAdOptionsAccessor)
+        {
+            if (option != null)
+            {
+                _cacheOptions = new MsalMemoryTokenCacheOptions();
+            }
+            else
+            {
+                _cacheOptions = option;
+            }
+
+            if (azureAdOptionsAccessor.CurrentValue == null && string.IsNullOrWhiteSpace(azureAdOptionsAccessor.CurrentValue.ClientId))
+            {
+                throw new ArgumentNullException(nameof(AzureADOptions), $"The app token cache needs {nameof(AzureADOptions)}, populated with clientId to initialize.");
+            }
+
+            _appId = azureAdOptionsAccessor.CurrentValue.ClientId;
+            _memoryCache = cache;
+        }
+
+        /// <summary>Initializes this instance of TokenCacheProvider with essentials to initialize themselves.</summary>
+        /// <param name="tokenCache">The token cache instance of MSAL application</param>
+        /// <param name="httpcontext">The Httpcontext whose Session will be used for caching.This is required by some providers.</param>
+        public void Initialize(ITokenCache tokenCache, HttpContext httpcontext)
+        {
+            _appCacheId = _appId + "_AppTokenCache";
+
+            ApptokenCache = tokenCache;
+            ApptokenCache.SetBeforeAccess(AppTokenCacheBeforeAccessNotification);
+            ApptokenCache.SetAfterAccess(AppTokenCacheAfterAccessNotification);
+            ApptokenCache.SetBeforeWrite(AppTokenCacheBeforeWriteNotification);
+
+            LoadAppTokenCacheFromMemory();
+        }
+
+        /// <summary>
+        /// if you want to ensure that no concurrent write take place, use this notification to place a lock on the entry
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void AppTokenCacheBeforeWriteNotification(TokenCacheNotificationArgs args)
+        {
+            // Since we are using a MemoryCache ,whose methods are threads safe, we need not to do anything in this handler.
+        }
+
+        /// <summary>
+        /// Loads the application's token from memory cache.
+        /// </summary>
+        private void LoadAppTokenCacheFromMemory()
+        {
+            byte[] tokenCacheBytes = (byte[])_memoryCache.Get(_appCacheId);
+            ApptokenCache.DeserializeMsalV3(tokenCacheBytes);
+        }
+
+        /// <summary>
+        /// Persists the application's token to the cache.
+        /// </summary>
+        private void PersistAppTokenCache()
+        {
+            // Reflect changes in the persistence store
+            _memoryCache.Set(_appCacheId, ApptokenCache.SerializeMsalV3(), _cacheOptions.AbsoluteExpiration);
+        }
+
+        /// <summary>
+        /// Clears the token cache for this app
+        /// </summary>
+        public void Clear()
+        {
+            _memoryCache.Remove(_appCacheId);
+
+            // Nulls the currently deserialized instance
+            LoadAppTokenCacheFromMemory();
+        }
+
+        /// <summary>
+        /// Triggered right before MSAL needs to access the cache. Reload the cache from the persistence store in case it changed since the last access.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void AppTokenCacheBeforeAccessNotification(TokenCacheNotificationArgs args)
+        {
+            LoadAppTokenCacheFromMemory();
+        }
+
+        /// <summary>
+        /// Triggered right after MSAL accessed the cache.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void AppTokenCacheAfterAccessNotification(TokenCacheNotificationArgs args)
+        {
+            // if the access operation resulted in a cache update
+            if (args.HasStateChanged)
+            {
+                PersistAppTokenCache();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/InMemory/MsalMemoryTokenCacheOptions.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/InMemory/MsalMemoryTokenCacheOptions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders.InMemory
+{
+    /// <summary>
+    /// MSAL's memory token cache options
+    /// </summary>
+    public class MsalMemoryTokenCacheOptions
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public MsalMemoryTokenCacheOptions()
+        {
+            AbsoluteExpiration = DateTimeOffset.Now.AddHours(12);
+        }
+
+        /// <summary>
+        /// Gets or sets the value of The fixed date and time at which the cache entry will expire..
+        /// The duration till the tokens are kept in memory cache. In production, a higher value , upto 90 days is recommended.
+        /// </summary>
+        /// <value>
+        /// The AbsoluteExpiration value.
+        /// </value>
+        public DateTimeOffset AbsoluteExpiration { get; set; }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/InMemory/MsalPerUserMemoryTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/InMemory/MsalPerUserMemoryTokenCacheProvider.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders.InMemory
+{
+    /// <summary>
+    /// An implementation of token cache for both Confidential and Public clients backed by MemoryCache.
+    /// MemoryCache is useful in Api scenarios where there is no HttpContext.Session to cache data.
+    /// </summary>
+    /// <remarks>https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/token-cache-serialization</remarks>
+    public class MsalPerUserMemoryTokenCacheProvider : IMsalUserTokenCacheProvider
+    {
+        /// <summary>
+        /// The backing MemoryCache instance
+        /// </summary>
+        internal IMemoryCache _memoryCache;
+
+        /// <summary>
+        /// The internal handle to the client's instance of the Cache
+        /// </summary>
+        private ITokenCache _userTokenCache;
+
+        /// <summary>
+        /// Once the user signes in, this will not be null and can be ontained via a call to Thread.CurrentPrincipal
+        /// </summary>
+        internal ClaimsPrincipal _signedInUser;
+
+        private readonly MsalMemoryTokenCacheOptions _cacheOptions;
+
+        /// <summary>Initializes a new instance of the <see cref="MsalPerUserMemoryTokenCacheProvider"/> class.</summary>
+        /// <param name="cache">The memory cache instance</param>
+        /// <param name="option"></param>
+        public MsalPerUserMemoryTokenCacheProvider(IMemoryCache cache, MsalMemoryTokenCacheOptions option)
+        {
+            _memoryCache = cache;
+
+            if (option != null)
+            {
+                _cacheOptions = new MsalMemoryTokenCacheOptions();
+            }
+            else
+            {
+                _cacheOptions = option;
+            }
+        }
+
+        /// <summary>Initializes this instance of TokenCacheProvider with essentials to initialize themselves.</summary>
+        /// <param name="tokenCache">The token cache instance of MSAL application</param>
+        /// <param name="httpcontext">The Httpcontext whose Session will be used for caching.This is required by some providers.</param>
+        /// <param name="user">The signed-in user for whom the cache needs to be established. Not needed by all providers.</param>
+        public void Initialize(ITokenCache tokenCache, HttpContext httpcontext, ClaimsPrincipal user)
+        {
+            _signedInUser = user;
+
+            _userTokenCache = tokenCache;
+            _userTokenCache.SetBeforeAccess(UserTokenCacheBeforeAccessNotification);
+            _userTokenCache.SetAfterAccess(UserTokenCacheAfterAccessNotification);
+            _userTokenCache.SetBeforeWrite(UserTokenCacheBeforeWriteNotification);
+
+            if (_signedInUser == null)
+            {
+                // No users signed in yet, so we return
+                return;
+            }
+
+            LoadUserTokenCacheFromMemory();
+        }
+
+        /// <summary>
+        /// Explores the Claims of a signed-in user (if available) to populate the unique Id of this cache's instance.
+        /// </summary>
+        /// <returns>The signed in user's object.tenant Id , if available in the ClaimsPrincipal.Current instance</returns>
+        internal string GetMsalAccountId()
+        {
+            if (_signedInUser != null)
+            {
+                return _signedInUser.GetMsalAccountId();
+            }
+            return null;
+        }
+
+        /// <summary>Loads the user token cache from memory.</summary>
+        private void LoadUserTokenCacheFromMemory()
+        {
+            string cacheKey = GetMsalAccountId();
+
+            if (string.IsNullOrWhiteSpace(cacheKey))
+            {
+                return;
+            }
+
+            byte[] tokenCacheBytes = (byte[])_memoryCache.Get(GetMsalAccountId());
+            _userTokenCache.DeserializeMsalV3(tokenCacheBytes);
+        }
+
+        /// <summary>
+        /// Persists the user token blob to the memoryCache.
+        /// </summary>
+        private void PersistUserTokenCache()
+        {
+            // Ideally, methods that load and persist should be thread safe.MemoryCache.Get() is thread safe.
+            _memoryCache.Set(GetMsalAccountId(), _userTokenCache.SerializeMsalV3(), _cacheOptions.AbsoluteExpiration);
+        }
+
+        /// <summary>
+        /// Clears the TokenCache's copy of this user's cache.
+        /// </summary>
+        public void Clear()
+        {
+            _memoryCache.Remove(GetMsalAccountId());
+
+            // Nulls the currently deserialized instance
+            LoadUserTokenCacheFromMemory();
+        }
+
+        /// <summary>
+        /// Triggered right after MSAL accessed the cache.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void UserTokenCacheAfterAccessNotification(TokenCacheNotificationArgs args)
+        {
+            SetSignedInUserFromNotificationArgs(args);
+
+            // if the access operation resulted in a cache update
+            if (args.HasStateChanged)
+            {
+                PersistUserTokenCache();
+            }
+        }
+
+        /// <summary>
+        /// Triggered right before MSAL needs to access the cache. Reload the cache from the persistence store in case it
+        /// changed since the last access.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void UserTokenCacheBeforeAccessNotification(TokenCacheNotificationArgs args)
+        {
+            LoadUserTokenCacheFromMemory();
+        }
+
+        /// <summary>
+        /// if you want to ensure that no concurrent write take place, use this notification to place a lock on the entry
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void UserTokenCacheBeforeWriteNotification(TokenCacheNotificationArgs args)
+        {
+        }
+
+        /// <summary>
+        /// To keep the cache, ClaimsPrincipal and Sql in sync, we ensure that the user's object Id we obtained by MSAL after
+        /// successful sign-in is set as the key for the cache.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void SetSignedInUserFromNotificationArgs(TokenCacheNotificationArgs args)
+        {
+            if (_signedInUser == null && args.Account != null)
+            {
+                _signedInUser = args.Account.ToClaimsPrincipal();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Session/MsalAppSessionTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Session/MsalAppSessionTokenCacheProvider.cs
@@ -1,0 +1,179 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders.Session
+{
+    /// <summary>
+    /// An implementation of token cache for Confidential clients backed by Http session.
+    /// </summary>
+    /// <remarks>https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/token-cache-serialization</remarks>
+    public class MsalAppSessionTokenCacheProvider : IMsalAppTokenCacheProvider
+    {
+        /// <summary>
+        /// The application cache key
+        /// </summary>
+        internal string _appCacheId;
+
+        /// <summary>
+        /// The HTTP context being used by this app
+        /// </summary>
+        internal HttpContext _httpContext = null;
+
+        /// <summary>
+        /// The duration till the tokens are kept in memory cache. In production, a higher value , upto 90 days is recommended.
+        /// </summary>
+        private readonly DateTimeOffset _cacheDuration = DateTimeOffset.Now.AddHours(12);
+
+        /// <summary>
+        /// The internal handle to the client's instance of the Cache
+        /// </summary>
+        private ITokenCache _apptokenCache;
+
+        private static readonly ReaderWriterLockSlim s_sessionLock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
+
+        /// <summary>
+        /// The App's whose cache we are maintaining.
+        /// </summary>
+        private readonly string _appId;
+
+        /// <summary>Initializes a new instance of the <see cref="MsalAppSessionTokenCacheProvider"/> class.</summary>
+        /// <param name="azureAdOptionsAccessor">The azure ad options accessor.</param>
+        /// <exception cref="ArgumentNullException">AzureADOptions - The app token cache needs {nameof(AzureADOptions)}</exception>
+        public MsalAppSessionTokenCacheProvider(IOptionsMonitor<AzureADOptions> azureAdOptionsAccessor)
+        {
+            if (azureAdOptionsAccessor.CurrentValue == null && string.IsNullOrWhiteSpace(azureAdOptionsAccessor.CurrentValue.ClientId))
+            {
+                throw new ArgumentNullException(nameof(AzureADOptions), $"The app token cache needs {nameof(AzureADOptions)}, populated with clientId to initialize.");
+            }
+
+            _appId = azureAdOptionsAccessor.CurrentValue.ClientId;
+        }
+
+        /// <summary>Initializes this instance of TokenCacheProvider with essentials to initialize themselves.</summary>
+        /// <param name="tokenCache">The token cache instance of MSAL application</param>
+        /// <param name="httpcontext">The Httpcontext whose Session will be used for caching.This is required by some providers.</param>
+        public void Initialize(ITokenCache tokenCache, HttpContext httpcontext)
+        {
+            _appCacheId = _appId + "_AppTokenCache";
+            _httpContext = httpcontext;
+
+            _apptokenCache = tokenCache;
+            _apptokenCache.SetBeforeAccess(AppTokenCacheBeforeAccessNotification);
+            _apptokenCache.SetAfterAccess(AppTokenCacheAfterAccessNotification);
+            _apptokenCache.SetBeforeWrite(AppTokenCacheBeforeWriteNotification);
+
+            LoadAppTokenCacheFromSession();
+        }
+
+        /// <summary>
+        /// if you want to ensure that no concurrent write take place, use this notification to place a lock on the entry
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void AppTokenCacheBeforeWriteNotification(TokenCacheNotificationArgs args)
+        {
+            // Since we are using a SessionCache ,whose methods are threads safe, we need not to do anything in this handler.
+        }
+
+        /// <summary>
+        /// Loads the application's tokens from session cache.
+        /// </summary>
+        private void LoadAppTokenCacheFromSession()
+        {
+            _httpContext.Session.LoadAsync().Wait();
+
+            s_sessionLock.EnterReadLock();
+            try
+            {
+                byte[] blob;
+                if (_httpContext.Session.TryGetValue(_appCacheId, out blob))
+                {
+                    Debug.WriteLine($"INFO: Deserializing session {_httpContext.Session.Id}, cacheId {_appCacheId}");
+                    _apptokenCache.DeserializeMsalV3(blob);
+                }
+                else
+                {
+                    Debug.WriteLine($"INFO: cacheId {_appCacheId} not found in session {_httpContext.Session.Id}");
+                }
+            }
+            finally
+            {
+                s_sessionLock.ExitReadLock();
+            }
+        }
+
+        /// <summary>
+        /// Persists the application token's to session cache.
+        /// </summary>
+        private void PersistAppTokenCache()
+        {
+            s_sessionLock.EnterWriteLock();
+
+            try
+            {
+                Debug.WriteLine($"INFO: Serializing session {_httpContext.Session.Id}, cacheId {_appCacheId}");
+
+                // Reflect changes in the persistent store
+                byte[] blob = _apptokenCache.SerializeMsalV3();
+                _httpContext.Session.Set(_appCacheId, blob);
+                _httpContext.Session.CommitAsync().Wait();
+            }
+            finally
+            {
+                s_sessionLock.ExitWriteLock();
+            }
+        }
+
+        /// <summary>
+        /// Clears the TokenCache's copy of this user's cache.
+        /// </summary>
+        public void Clear()
+        {
+            s_sessionLock.EnterWriteLock();
+
+            try
+            {
+                Debug.WriteLine($"INFO: Clearing session {_httpContext.Session.Id}, cacheId {_appCacheId}");
+
+                // Reflect changes in the persistent store
+                _httpContext.Session.Remove(_appCacheId);
+                _httpContext.Session.CommitAsync().Wait();
+            }
+            finally
+            {
+                s_sessionLock.ExitWriteLock();
+            }
+
+            // Nulls the currently deserialized instance
+            LoadAppTokenCacheFromSession();
+        }
+
+        /// <summary>
+        /// Triggered right before MSAL needs to access the cache. Reload the cache from the persistence store in case it changed since the last access.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void AppTokenCacheBeforeAccessNotification(TokenCacheNotificationArgs args)
+        {
+            LoadAppTokenCacheFromSession();
+        }
+
+        /// <summary>
+        /// Triggered right after MSAL accessed the cache.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void AppTokenCacheAfterAccessNotification(TokenCacheNotificationArgs args)
+        {
+            // if the access operation resulted in a cache update
+            if (args.HasStateChanged)
+            {
+                PersistAppTokenCache();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Session/MsalPerUserSessionTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Session/MsalPerUserSessionTokenCacheProvider.cs
@@ -1,0 +1,217 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using System.Security.Claims;
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders.Session
+{
+    /// <summary>
+    /// This is a MSAL's TokenCache implementation for one user. It uses Http session as a backend store
+    /// </summary>
+    public class MsalPerUserSessionTokenCacheProvider : IMsalUserTokenCacheProvider
+    {
+        private static readonly ReaderWriterLockSlim s_sessionLock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
+
+        /// <summary>
+        /// Once the user signes in, this will not be null and can be ontained via a call to ClaimsPrincipal.Current
+        /// </summary>
+        internal ClaimsPrincipal _signedInUser;
+
+        /// <summary>
+        /// The HTTP context being used by this app
+        /// </summary>
+        internal HttpContext _httpContext = null;
+
+        /// <summary>
+        /// The internal handle to the client's instance of the Cache
+        /// </summary>
+        private ITokenCache _userTokenCache;
+
+        /// <summary>Initializes a new instance of the <see cref="MsalPerUserSessionTokenCacheProvider"/> class.</summary>
+        public MsalPerUserSessionTokenCacheProvider()
+        {
+        }
+
+        /// <summary>Initializes the cache instance</summary>
+        /// <param name="tokenCache">The ITokenCache passed through the constructor</param>
+        /// <param name="httpcontext">The current HttpContext</param>
+        /// <param name="user">The signed in user's ClaimPrincipal, could be null.
+        /// If the calling app has it available, then it should pass it themselves.</param>
+        public void Initialize(ITokenCache tokenCache, HttpContext httpcontext, ClaimsPrincipal user)
+        {
+            _httpContext = httpcontext;
+
+            _userTokenCache = tokenCache;
+
+            _userTokenCache.SetBeforeAccess(UserTokenCacheBeforeAccessNotification);
+            _userTokenCache.SetAfterAccess(UserTokenCacheAfterAccessNotification);
+            _userTokenCache.SetBeforeWrite(UserTokenCacheBeforeWriteNotification);
+
+            if (user == null)
+            {
+                // No users signed in yet, so we return
+                return;
+            }
+
+            _signedInUser = user;
+            LoadUserTokenCacheFromSession();
+        }
+
+        /// <summary>
+        /// Loads the user token cache from http session.
+        /// </summary>
+        private void LoadUserTokenCacheFromSession()
+        {
+            _httpContext.Session.LoadAsync().Wait();
+
+            string cacheKey = GetSignedInUsersUniqueId();
+
+            if (string.IsNullOrWhiteSpace(cacheKey))
+            {
+                return;
+            }
+
+            s_sessionLock.EnterReadLock();
+            try
+            {
+                byte[] blob;
+                if (_httpContext.Session.TryGetValue(cacheKey, out blob))
+                {
+                    Debug.WriteLine($"INFO: Deserializing session {_httpContext.Session.Id}, cacheId {cacheKey}");
+                    _userTokenCache.DeserializeMsalV3(blob);
+                }
+                else
+                {
+                    Debug.WriteLine($"INFO: cacheId {cacheKey} not found in session {_httpContext.Session.Id}");
+                }
+            }
+            finally
+            {
+                s_sessionLock.ExitReadLock();
+            }
+        }
+
+        /// <summary>
+        /// Persists the user token blob to the Http session.
+        /// </summary>
+        private void PersistUserTokenCache()
+        {
+            string cacheKey = GetSignedInUsersUniqueId();
+
+            if (string.IsNullOrWhiteSpace(cacheKey))
+            {
+                return;
+            }
+
+            s_sessionLock.EnterWriteLock();
+
+            try
+            {
+                Debug.WriteLine($"INFO: Serializing session {_httpContext.Session.Id}, cacheId {cacheKey}");
+
+                // Reflect changes in the persistent store
+                byte[] blob = _userTokenCache.SerializeMsalV3();
+                _httpContext.Session.Set(cacheKey, blob);
+                _httpContext.Session.CommitAsync().Wait();
+            }
+            finally
+            {
+                s_sessionLock.ExitWriteLock();
+            }
+        }
+
+        /// <summary>
+        /// Clears the TokenCache's copy of this user's cache.
+        /// </summary>
+        public void Clear()
+        {
+            string cacheKey = GetSignedInUsersUniqueId();
+
+            if (string.IsNullOrWhiteSpace(cacheKey))
+            {
+                return;
+            }
+
+            s_sessionLock.EnterWriteLock();
+
+            try
+            {
+                Debug.WriteLine($"INFO: Clearing session {_httpContext.Session.Id}, cacheId {cacheKey}");
+
+                // Reflect changes in the persistent store
+                _httpContext.Session.Remove(cacheKey);
+                _httpContext.Session.CommitAsync().Wait();
+            }
+            finally
+            {
+                s_sessionLock.ExitWriteLock();
+            }
+
+            // Nulls the currently deserialized instance
+            LoadUserTokenCacheFromSession();
+        }
+
+        /// <summary>
+        /// if you want to ensure that no concurrent write take place, use this notification to place a lock on the entry
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+
+        private void UserTokenCacheBeforeWriteNotification(TokenCacheNotificationArgs args)
+        {
+            // Since we obtain and release lock right before and after we read the Http session, we need not do anything here.
+        }
+
+        /// <summary>
+        /// Triggered right after MSAL accessed the cache.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void UserTokenCacheAfterAccessNotification(TokenCacheNotificationArgs args)
+        {
+            SetSignedInUserFromNotificationArgs(args);
+
+            // if the access operation resulted in a cache update
+            if (args.HasStateChanged)
+            {
+                PersistUserTokenCache();
+            }
+        }
+
+        /// <summary>
+        /// To keep the cache, ClaimsPrincipal and Sql in sync, we ensure that the user's object Id we obtained by MSAL after
+        /// successful sign-in is set as the key for the cache.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void SetSignedInUserFromNotificationArgs(TokenCacheNotificationArgs args)
+        {
+            if (_signedInUser == null && args.Account != null)
+            {
+                _signedInUser = args.Account.ToClaimsPrincipal();
+            }
+        }
+
+        /// <summary>
+        /// Triggered right before MSAL needs to access the cache. Reload the cache from the persistence store in case it changed since the last access.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void UserTokenCacheBeforeAccessNotification(TokenCacheNotificationArgs args)
+        {
+            LoadUserTokenCacheFromSession();
+        }
+
+        /// <summary>
+        /// Explores the Claims of a signed-in user (if available) to populate the unique Id of this cache's instance.
+        /// </summary>
+        /// <returns>The signed in user's object.tenant Id , if available in the ClaimsPrincipal.Current instance</returns>
+        internal string GetSignedInUsersUniqueId()
+        {
+            if (_signedInUser != null)
+            {
+                return _signedInUser.GetMsalAccountId();
+            }
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Session/SessionServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Session/SessionServiceCollectionExtensions.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders.Session
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public static class SessionServiceCollectionExtensions
+    {
+        /// <summary>Adds both App and per-user session token caches.</summary>
+        /// <param name="services">The services collection to add to.</param>
+        /// <returns></returns>
+        public static IServiceCollection AddSessionTokenCaches(this IServiceCollection services)
+        {
+            AddSessionAppTokenCache(services);
+            AddSessionPerUserTokenCache(services);
+
+            return services;
+        }
+
+        /// <summary>Adds the Http session based application token cache to the service collection.</summary>
+        /// <param name="services">The services collection to add to.</param>
+        /// <returns></returns>
+        public static IServiceCollection AddSessionAppTokenCache(this IServiceCollection services)
+        {
+            services.AddScoped<IMsalAppTokenCacheProvider>(factory =>
+            {
+                var optionsMonitor = factory.GetRequiredService<IOptionsMonitor<AzureADOptions>>();
+
+                return new MsalAppSessionTokenCacheProvider(optionsMonitor);
+            });
+
+            return services;
+        }
+
+        /// <summary>Adds the http session based per user token cache to the service collection.</summary>
+        /// <param name="services">The services collection to add to.</param>
+        /// <returns></returns>
+        public static IServiceCollection AddSessionPerUserTokenCache(this IServiceCollection services)
+        {
+            services.AddScoped<IMsalUserTokenCacheProvider, MsalPerUserSessionTokenCacheProvider>();
+            return services;
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Sql/AppTokenCache.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Sql/AppTokenCache.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders.Sql
+{
+    /// <summary>
+    /// Represents an app's token cache entry in database
+    /// </summary>
+    public class AppTokenCache
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        [Key]
+        public int AppTokenCacheId { get; set; }
+
+        /// <summary>
+        /// The Appid or ClientId of the app
+        /// </summary>
+        public string ClientID { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public byte[] CacheBits { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public DateTime LastWrite { get; set; }
+
+        /// <summary>
+        /// Provided here as a precaution against concurrent updates by multiple threads.
+        /// </summary>
+        [Timestamp]
+        public byte[] RowVersion { get; set; }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Sql/MsalAppSqlTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Sql/MsalAppSqlTokenCacheProvider.cs
@@ -1,0 +1,179 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders.Sql
+{
+    /// <summary>
+    /// An implementation of token cache for Confidential clients backed by Sql server and Entity Framework
+    /// </summary>
+    /// <remarks>https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/token-cache-serialization</remarks>
+    public class MsalAppSqlTokenCacheProvider : IMsalAppTokenCacheProvider
+    {
+        /// <summary>
+        /// The EF's DBContext object to be used to read and write from the Sql server database.
+        /// </summary>
+        private readonly TokenCacheDbContext _tokenCacheDb;
+
+        /// <summary>
+        /// This keeps the latest copy of the token in memory to save calls to DB, if possible.
+        /// </summary>
+        private AppTokenCache _inMemoryCache;
+
+        /// <summary>
+        /// The internal handle to the client's instance of the Cache
+        /// </summary>
+        private ITokenCache _apptokenCache;
+
+        /// <summary>
+        /// The data protector
+        /// </summary>
+        private readonly IDataProtector _dataProtector;
+
+        /// <summary>
+        /// Once a app obtains a token, this is populated and used for caching queries et al. Contains the App's AppId/ClientID as obtained from the Azure AD portal
+        /// </summary>
+        internal string _activeClientId;
+
+        /// <summary>Initializes a new instance of the <see cref="MsalAppSqlTokenCacheProvider"/> class.</summary>
+        /// <param name="tokenCacheDbContext">The TokenCacheDbContext DbContext to read and write from Sql server.</param>
+        /// <param name="azureAdOptionsAccessor"></param>
+        /// <param name="protectionProvider">The data protection provider. Requires the caller to have used serviceCollection.AddDataProtection();</param>
+        public MsalAppSqlTokenCacheProvider(TokenCacheDbContext tokenCacheDbContext, IOptionsMonitor<AzureADOptions> azureAdOptionsAccessor, IDataProtectionProvider protectionProvider)
+        {
+            if (protectionProvider == null)
+            {
+                throw new ArgumentNullException(nameof(protectionProvider), $"The app token cache needs an {nameof(IDataProtectionProvider)} to operate. Please use 'serviceCollection.AddDataProtection();' to add the data protection provider to the service collection");
+            }
+
+            if (azureAdOptionsAccessor.CurrentValue == null && string.IsNullOrWhiteSpace(azureAdOptionsAccessor.CurrentValue.ClientId))
+            {
+                throw new ArgumentNullException(nameof(protectionProvider), $"The app token cache needs {nameof(AzureADOptions)}, populated with both Sql connection string and clientId to initialize.");
+            }
+
+            _dataProtector = protectionProvider.CreateProtector("MSAL");
+            _tokenCacheDb = tokenCacheDbContext;
+            _activeClientId = azureAdOptionsAccessor.CurrentValue.ClientId;
+        }
+
+        /// <summary>Initializes this instance of TokenCacheProvider with essentials to initialize themselves.</summary>
+        /// <param name="tokenCache">The token cache instance of MSAL application</param>
+        /// <param name="httpcontext">The Httpcontext whose Session will be used for caching.This is required by some providers.</param>
+        public void Initialize(ITokenCache tokenCache, HttpContext httpcontext)
+        {
+            _apptokenCache = tokenCache;
+            _apptokenCache.SetBeforeAccess(AppTokenCacheBeforeAccessNotification);
+            _apptokenCache.SetAfterAccess(AppTokenCacheAfterAccessNotification);
+            _apptokenCache.SetBeforeWrite(AppTokenCacheBeforeWriteNotification);
+
+            ReadCacheForSignedInApp();
+        }
+
+        /// <summary>
+        /// if you want to ensure that no concurrent write take place, use this notification to place a lock on the entry
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void AppTokenCacheBeforeWriteNotification(TokenCacheNotificationArgs args)
+        {
+            // Since we are using a Rowversion for concurrency, we need not to do anything in this handler.
+        }
+
+        /// <summary>
+        /// Raised AFTER MSAL added the new token in its in-memory copy of the cache.
+        /// This notification is called every time MSAL accessed the cache, not just when a write took place:
+        /// If MSAL's current operation resulted in a cache change, the property TokenCacheNotificationArgs.HasStateChanged will be set to true.
+        /// If that is the case, we call the TokenCache.Serialize() to get a binary blob representing the latest cache content – and persist it.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void AppTokenCacheAfterAccessNotification(TokenCacheNotificationArgs args)
+        {
+            // if state changed, i.e. new token obtained
+            if (args.HasStateChanged && !string.IsNullOrWhiteSpace(_activeClientId))
+            {
+                if (_inMemoryCache == null)
+                {
+                    _inMemoryCache = new AppTokenCache
+                    {
+                        ClientID = _activeClientId
+                    };
+                }
+
+                _inMemoryCache.CacheBits = _dataProtector.Protect(_apptokenCache.SerializeMsalV3());
+                _inMemoryCache.LastWrite = DateTime.Now;
+
+                try
+                {
+                    // Update the DB and the lastwrite
+                    _tokenCacheDb.Entry(_inMemoryCache).State = _inMemoryCache.AppTokenCacheId == 0 ? EntityState.Added : EntityState.Modified;
+                    _tokenCacheDb.SaveChanges();
+                }
+                catch (DbUpdateConcurrencyException)
+                {
+                    // Record already updated on a different thread, so just read the updated record
+                    ReadCacheForSignedInApp();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clears all tokens belonging to the currently signed-in client Id from database
+        /// </summary>
+        public void Clear()
+        {
+            var cacheEntries = _tokenCacheDb.AppTokenCache.Where(c => c.ClientID == _activeClientId);
+            _tokenCacheDb.AppTokenCache.RemoveRange(cacheEntries);
+            _tokenCacheDb.SaveChanges();
+
+            // Nulls the currently deserialized instance
+            ReadCacheForSignedInApp();
+        }
+
+        /// <summary>
+        /// Right before it reads the cache, a call is made to BeforeAccess notification. Here, you have the opportunity of retrieving your persisted cache blob
+        /// from the Sql database. We pick it from the database, save it in the in-memory copy, and pass it to the base class by calling the Deserialize().
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void AppTokenCacheBeforeAccessNotification(TokenCacheNotificationArgs args)
+        {
+            ReadCacheForSignedInApp();
+        }
+
+        /// <summary>
+        /// Reads the cache data from the backend database.
+        /// </summary>
+        private void ReadCacheForSignedInApp()
+        {
+            if (_inMemoryCache == null) // first time access
+            {
+                _inMemoryCache = GetLatestAppRecordQuery().FirstOrDefault();
+            }
+            else
+            {
+                // retrieve last written record from the DB
+                var lastwriteInDb = GetLatestAppRecordQuery().Select(n => n.LastWrite).FirstOrDefault();
+
+                // if the persisted copy is newer than the in-memory copy
+                if (lastwriteInDb > _inMemoryCache.LastWrite)
+                {
+                    // read from from storage, update in-memory copy
+                    _inMemoryCache = GetLatestAppRecordQuery().FirstOrDefault();
+                }
+            }
+
+            // Send data to the TokenCache instance
+            _apptokenCache.DeserializeMsalV3((_inMemoryCache == null) ? null : _dataProtector.Unprotect(_inMemoryCache.CacheBits));
+        }
+
+        private IOrderedQueryable<AppTokenCache> GetLatestAppRecordQuery()
+        {
+            return _tokenCacheDb.AppTokenCache.Where(c => c.ClientID == _activeClientId).OrderByDescending(d => d.LastWrite);
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Sql/MsalPerUserSqlTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Sql/MsalPerUserSqlTokenCacheProvider.cs
@@ -1,0 +1,261 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Security.Claims;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders.Sql
+{
+    /// <summary>
+    /// This is a MSAL's TokenCache implementation for one user. It uses Sql server as a backend store and uses the Entity Framework to read and write to that database.
+    /// </summary>
+    /// <remarks>https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/token-cache-serialization</remarks>
+    public class MsalPerUserSqlTokenCacheProvider : IMsalUserTokenCacheProvider
+    {
+        /// <summary>
+        /// The EF's DBContext object to be used to read and write from the Sql server database.
+        /// </summary>
+        private readonly TokenCacheDbContext _tokenCacheDb;
+
+        /// <summary>
+        /// This keeps the latest copy of the token in memory to save calls to DB, if possible.
+        /// </summary>
+        private UserTokenCache _inMemoryCache;
+
+        /// <summary>
+        /// The private MSAL's TokenCache instance.
+        /// </summary>
+        private ITokenCache _userTokenCache;
+
+        /// <summary>
+        /// Once the user signes in, this will not be null and can be ontained via a call to Thread.CurrentPrincipal
+        /// </summary>
+        internal ClaimsPrincipal _signedInUser;
+
+        /// <summary>
+        /// The data protector
+        /// </summary>
+        private readonly IDataProtector _dataProtector;
+
+        /// <summary>Initializes a new instance of the <see cref="MsalPerUserSqlTokenCacheProvider"/> class.</summary>
+        /// <param name="protectionProvider">The data protection provider. Requires the caller to have used serviceCollection.AddDataProtection();</param>
+        /// <param name="tokenCacheDbContext">The DbContext to the database where tokens will be cached.</param>
+        public MsalPerUserSqlTokenCacheProvider(
+            TokenCacheDbContext tokenCacheDbContext,
+            IDataProtectionProvider protectionProvider)
+            : this(tokenCacheDbContext, protectionProvider, ClaimsPrincipal.Current)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="MsalPerUserSqlTokenCacheProvider"/> class.</summary>
+        /// <param name="tokenCacheDbContext">The token cache database context.</param>
+        /// <param name="protectionProvider">The protection provider.</param>
+        /// <param name="user">The current user .</param>
+        /// <exception cref="ArgumentNullException">protectionProvider - The app token cache needs an {nameof(IDataProtectionProvider)}</exception>
+        public MsalPerUserSqlTokenCacheProvider(
+            TokenCacheDbContext tokenCacheDbContext,
+            IDataProtectionProvider protectionProvider,
+            ClaimsPrincipal user)
+        {
+            if (protectionProvider == null)
+            {
+                throw new ArgumentNullException(nameof(protectionProvider), $"The app token cache needs an {nameof(IDataProtectionProvider)} to operate. Please use 'serviceCollection.AddDataProtection();' to add the data protection provider to the service collection");
+            }
+
+            _dataProtector = protectionProvider.CreateProtector("MSAL");
+            _tokenCacheDb = tokenCacheDbContext;
+            _signedInUser = user;
+        }
+
+        /// <summary>Initializes this instance of TokenCacheProvider with essentials to initialize themselves.</summary>
+        /// <param name="tokenCache">The token cache instance of MSAL application</param>
+        /// <param name="httpcontext">The Httpcontext whose Session will be used for caching.This is required by some providers.</param>
+        /// <param name="user">The signed-in user for whom the cache needs to be established. Not needed by all providers.</param>
+        public void Initialize(ITokenCache tokenCache, HttpContext httpcontext, ClaimsPrincipal user)
+        {
+            _userTokenCache = tokenCache;
+            _userTokenCache.SetBeforeAccess(UserTokenCacheBeforeAccessNotification);
+            _userTokenCache.SetAfterAccess(UserTokenCacheAfterAccessNotification);
+            _userTokenCache.SetBeforeWrite(UserTokenCacheBeforeWriteNotification);
+
+            if (user == null)
+            {
+                // No users signed in yet, so we return
+                return;
+            }
+
+            _signedInUser = user;
+            ReadCacheForSignedInUser();
+        }
+
+        /// <summary>
+        /// Explores the Claims of a signed-in user (if available) to populate the unique Id of this cache's instance.
+        /// </summary>
+        /// <returns>The signed in user's object.tenant Id , if available in the ClaimsPrincipal.Current instance</returns>
+        private string GetSignedInUsersUniqueId()
+        {
+            if (_signedInUser != null)
+            {
+                return _signedInUser.GetMsalAccountId();
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// if you want to ensure that no concurrent write take place, use this notification to place a lock on the entry
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void UserTokenCacheBeforeWriteNotification(TokenCacheNotificationArgs args)
+        {
+            // Since we are using a Rowversion for concurrency, we need not to do anything in this handler.
+        }
+
+        /// <summary>
+        /// Right before it reads the cache, a call is made to BeforeAccess notification. Here, you have the opportunity of retrieving your persisted cache blob
+        /// from the Sql database. We pick it from the database, save it in the in-memory copy, and pass it to the base class by calling the Deserialize().
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void UserTokenCacheBeforeAccessNotification(TokenCacheNotificationArgs args)
+        {
+            ReadCacheForSignedInUser();
+        }
+
+        /// <summary>
+        /// Raised AFTER MSAL added the new token in its in-memory copy of the cache.
+        /// This notification is called every time MSAL accessed the cache, not just when a write took place:
+        /// If MSAL's current operation resulted in a cache change, the property TokenCacheNotificationArgs.HasStateChanged will be set to true.
+        /// If that is the case, we call the TokenCache.Serialize() to get a binary blob representing the latest cache content – and persist it.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void UserTokenCacheAfterAccessNotification(TokenCacheNotificationArgs args)
+        {
+            SetSignedInUserFromNotificationArgs(args);
+
+            // if state changed, i.e. new token obtained
+            if (args.HasStateChanged && !string.IsNullOrWhiteSpace(GetSignedInUsersUniqueId()))
+            {
+                if (_inMemoryCache == null)
+                {
+                    _inMemoryCache = new UserTokenCache
+                    {
+                        WebUserUniqueId = GetSignedInUsersUniqueId()
+                    };
+                }
+
+                _inMemoryCache.CacheBits = _dataProtector.Protect(_userTokenCache.SerializeMsalV3());
+                _inMemoryCache.LastWrite = DateTime.Now;
+
+                try
+                {
+                    // Update the DB and the lastwrite
+                    _tokenCacheDb.Entry(_inMemoryCache).State = _inMemoryCache.UserTokenCacheId == 0
+                        ? EntityState.Added
+                        : EntityState.Modified;
+
+                    _tokenCacheDb.SaveChanges();
+                }
+                catch (DbUpdateConcurrencyException)
+                {
+                    // Record already updated on a different thread, so just read the updated record
+                    ReadCacheForSignedInUser();
+                }
+            }
+        }
+
+        /// <summary>
+        /// To keep the cache, ClaimsPrincipal and Sql in sync, we ensure that the user's object Id we obtained by MSAL after
+        /// successful sign-in is set as the key for the cache.
+        /// </summary>
+        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
+        private void SetSignedInUserFromNotificationArgs(TokenCacheNotificationArgs args)
+        {
+            if (_signedInUser == null && args.Account != null)
+            {
+                _signedInUser = args.Account.ToClaimsPrincipal();
+            }
+        }
+
+        /// <summary>
+        /// Reads the cache data from the backend database.
+        /// </summary>
+        private void ReadCacheForSignedInUser()
+        {
+            if (_inMemoryCache == null) // first time access
+            {
+                _inMemoryCache = GetLatestUserRecordQuery().FirstOrDefault();
+            }
+            else
+            {
+                // retrieve last written record from the DB
+                var lastwriteInDb = GetLatestUserRecordQuery().Select(n => n.LastWrite).FirstOrDefault();
+
+                // if the persisted copy is newer than the in-memory copy
+                if (lastwriteInDb > _inMemoryCache.LastWrite)
+                {
+                    // read from from storage, update in-memory copy
+                    _inMemoryCache = GetLatestUserRecordQuery().FirstOrDefault();
+                }
+            }
+
+            // Send data to the TokenCache instance
+            _userTokenCache.DeserializeMsalV3((_inMemoryCache == null) ? null : _dataProtector.Unprotect(_inMemoryCache.CacheBits));
+        }
+
+        /// <summary>
+        /// Clears the TokenCache's copy and the database copy of this user's cache.
+        /// </summary>
+        public void Clear()
+        {
+            // Delete from DB
+            var cacheEntries = _tokenCacheDb.UserTokenCache.Where(c => c.WebUserUniqueId == GetSignedInUsersUniqueId());
+            _tokenCacheDb.UserTokenCache.RemoveRange(cacheEntries);
+            _tokenCacheDb.SaveChanges();
+
+            // Nulls the currently deserialized instance
+            ReadCacheForSignedInUser();
+        }
+
+        private IOrderedQueryable<UserTokenCache> GetLatestUserRecordQuery()
+        {
+            return _tokenCacheDb.UserTokenCache.Where(c => c.WebUserUniqueId == GetSignedInUsersUniqueId()).OrderByDescending(d => d.LastWrite);
+        }
+    }
+
+    /// <summary>
+    /// Represents a user's token cache entry in database
+    /// </summary>
+    public class UserTokenCache
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        [Key]
+        public int UserTokenCacheId { get; set; }
+
+        /// <summary>
+        /// The objectId of the signed-in user's object in Azure AD
+        /// </summary>
+        public string WebUserUniqueId { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public byte[] CacheBits { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public DateTime LastWrite { get; set; }
+
+        /// <summary>
+        /// Provided here as a precaution against concurrent updates by multiple threads.
+        /// </summary>
+        [Timestamp]
+        public byte[] RowVersion { get; set; }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Sql/MsalSqlTokenCacheOptions.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Sql/MsalSqlTokenCacheOptions.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders.Sql
+{
+    /// <summary>
+    /// MSAL's Sql token cache options
+    /// </summary>
+    public class MsalSqlTokenCacheOptions
+    {
+        /// <summary>Initializes a new instance of the <see cref="MsalSqlTokenCacheOptions"/> class.</summary>
+        /// <param name="sqlConnectionString">the SQL connection string to the token cache database.</param>
+        public MsalSqlTokenCacheOptions(string sqlConnectionString) :
+            this(sqlConnectionString, string.Empty)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="MsalSqlTokenCacheOptions"/> class.</summary>
+        /// <param name="sqlConnectionString">The SQL connection string.</param>
+        /// <param name="clientId">The the clientId of the application for whom this token cache instance is being created. (Optional for User cache).</param>
+        public MsalSqlTokenCacheOptions(string sqlConnectionString, string clientId)
+        {
+            SqlConnectionString = sqlConnectionString;
+            ClientId = clientId;
+        }
+
+        /// <summary>
+        /// Gets or sets the SQL connection string to the token cache database.
+        /// </summary>
+        public string SqlConnectionString { get; }
+
+        /// <summary>
+        /// Gets or sets the clientId of the application for whom this token cache instance is being created. (Optional)
+        /// </summary>
+        public string ClientId { get; set; }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Sql/SqlServiceCollectionExtensions.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Sql/SqlServiceCollectionExtensions.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders.Sql
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public static class MsalAppSqlTokenCacheProviderExtension
+    {
+        /// <summary>Adds the app and per user SQL token caches.</summary>
+        /// <param name="services">The services collection to add to.</param>
+        /// <param name="sqlTokenCacheOptions">The MSALSqlTokenCacheOptions is used by the caller to specify the Sql connection string</param>
+        /// <returns></returns>
+        public static IServiceCollection AddSqlTokenCaches(
+            this IServiceCollection services,
+            MsalSqlTokenCacheOptions sqlTokenCacheOptions)
+        {
+            AddSqlAppTokenCache(services, sqlTokenCacheOptions);
+            AddSqlPerUserTokenCache(services, sqlTokenCacheOptions);
+            return services;
+        }
+
+        /// <summary>Adds the Sql Server based application token cache to the service collection.</summary>
+        /// <param name="services">The services collection to add to.</param>
+        /// <param name="sqlTokenCacheOptions">The MSALSqlTokenCacheOptions is used by the caller to specify the Sql connection string</param>
+        /// <returns></returns>
+        public static IServiceCollection AddSqlAppTokenCache(
+            this IServiceCollection services,
+            MsalSqlTokenCacheOptions sqlTokenCacheOptions)
+        {
+            // Uncomment the following lines to create the database. In production scenarios, the database
+            // will most probably be already present.
+            //var tokenCacheDbContextBuilder = new DbContextOptionsBuilder<TokenCacheDbContext>();
+            //tokenCacheDbContextBuilder.UseSqlServer(configuration.GetConnectionString("TokenCacheDbConnStr"));
+
+            //var tokenCacheDbContext = new TokenCacheDbContext(tokenCacheDbContextBuilder.Options);
+            //tokenCacheDbContext.Database.EnsureCreated();
+
+            services.AddDataProtection();
+
+            services.AddDbContext<TokenCacheDbContext>(options =>
+                options.UseSqlServer(sqlTokenCacheOptions.SqlConnectionString));
+
+            services.AddScoped<IMsalAppTokenCacheProvider>(factory =>
+            {
+                var dpprovider = factory.GetRequiredService<IDataProtectionProvider>();
+                var tokenCacheDbContext = factory.GetRequiredService<TokenCacheDbContext>();
+                var optionsMonitor = factory.GetRequiredService<IOptionsMonitor<AzureADOptions>>();
+
+                return new MsalAppSqlTokenCacheProvider(tokenCacheDbContext, optionsMonitor, dpprovider);
+            });
+
+            return services;
+        }
+
+        /// <summary>Adds the Sql Server based per user token cache to the service collection.</summary>
+        /// <param name="services">The services collection to add to.</param>
+        /// <param name="sqlTokenCacheOptions">The MSALSqlTokenCacheOptions is used by the caller to specify the Sql connection string</param>
+        /// <returns></returns>
+        public static IServiceCollection AddSqlPerUserTokenCache(
+            this IServiceCollection services,
+            MsalSqlTokenCacheOptions sqlTokenCacheOptions)
+        {
+            // Uncomment the following lines to create the database. In production scenarios, the database
+            // will most probably be already present.
+            // var tokenCacheDbContextBuilder = new DbContextOptionsBuilder<TokenCacheDbContext>();
+            // tokenCacheDbContextBuilder.UseSqlServer(configuration.GetConnectionString("TokenCacheDbConnStr"));
+
+            // var tokenCacheDbContext = new TokenCacheDbContext(tokenCacheDbContextBuilder.Options);
+            // tokenCacheDbContext.Database.EnsureCreated();
+
+            services.AddDataProtection();
+
+            services.AddDbContext<TokenCacheDbContext>(options =>
+                options.UseSqlServer(sqlTokenCacheOptions.SqlConnectionString));
+
+            services.AddScoped<IMsalUserTokenCacheProvider>(factory =>
+            {
+                var dpprovider = factory.GetRequiredService<IDataProtectionProvider>();
+                var tokenCacheDbContext = factory.GetRequiredService<TokenCacheDbContext>();
+
+                return new MsalPerUserSqlTokenCacheProvider(tokenCacheDbContext, dpprovider);
+            });
+
+            return services;
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Sql/TokenCacheDbContext.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Sql/TokenCacheDbContext.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders.Sql
+{
+    /// <summary>
+    /// The DBContext that is used by the TokenCache providers to read and write to a Sql database.
+    /// </summary>
+    public class TokenCacheDbContext : DbContext
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="options"></param>
+        public TokenCacheDbContext(DbContextOptions<TokenCacheDbContext> options)
+            : base(options)
+        {
+        }
+
+        /// <summary>
+        /// The app token cache table
+        /// </summary>
+        public DbSet<AppTokenCache> AppTokenCache { get; set; }
+
+        /// <summary>
+        /// The user token cache table
+        /// </summary>
+        public DbSet<UserTokenCache> UserTokenCache { get; set; }
+    }
+}


### PR DESCRIPTION
This brings in the remaining classes from the Microsoft.Identity.Web sample library so we can look at wiring them into the samples and releasing this publicly.