### PR TITLE
Remove version checks from extensions library and simply deserialize

### DIFF
--- a/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheStorage.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheStorage.cs
@@ -20,9 +20,6 @@ namespace Microsoft.Identity.Client.Extensions.Msal
         internal readonly StorageCreationProperties _creationProperties;
         private readonly TraceSource _logger;
 
-        // This is set to empty string here. During a file read, if the token isn't available, we will create a new guid, so we will always read the first time.
-        private string _lastVersionToken = string.Empty;
-
         private IntPtr _libsecretSchema = IntPtr.Zero;
 
         /// <summary>
@@ -42,10 +39,6 @@ namespace Microsoft.Identity.Client.Extensions.Msal
         /// </summary>
         public string CacheFilePath => _creationProperties.CacheFilePath;
 
-        internal string VersionFilePath => CacheFilePath + ".version";
-
-        internal string LastVersionToken => string.Copy(_lastVersionToken);
-
         /// <summary>
         /// Gets a value indicating whether the persisted file has changed since we last read it.
         /// </summary>
@@ -53,49 +46,9 @@ namespace Microsoft.Identity.Client.Extensions.Msal
         {
             get
             {
-                bool versionFileExists = File.Exists(VersionFilePath);
-                _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Has the store changed");
-                _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"VersionFileExists '{versionFileExists}'");
-
-                if (!versionFileExists)
-                {
-                    _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"The version file does not exist, treat as 'changed'.");
-                    return true;
-                }
-
-                string currentVersion = File.ReadAllText(VersionFilePath);
-                _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Current version '{currentVersion}' Last version '{_lastVersionToken}'");
-
-                bool hasChanged = !currentVersion.Equals(_lastVersionToken, StringComparison.OrdinalIgnoreCase);
-
-                _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Cache has changed '{hasChanged}'");
-                return hasChanged;
-            }
-        }
-
-        private void WriteVersionFile()
-        {
-            try
-            {
-                string newVersion = Guid.NewGuid().ToString();
-                File.WriteAllText(VersionFilePath, newVersion);
-                _lastVersionToken = newVersion;
-            }
-            catch (IOException ex)
-            {
-                _logger.TraceEvent(TraceEventType.Warning, /*id*/ 0, $"Unable to write version file due to exception: '{ex.Message}'");
-            }
-        }
-
-        private void CacheLastReadVersion()
-        {
-            try
-            {
-                _lastVersionToken = File.ReadAllText(VersionFilePath);
-            }
-            catch (IOException ex)
-            {
-                _logger.TraceEvent(TraceEventType.Warning, /*id*/ 0, $"Unable to read version file due to exception: '{ex.Message}'");
+                // Attempts to make this more refined have all resulted in some form of cache inconsistency. Just returning
+                // true here so we always load from disk.
+                return true;
             }
         }
 
@@ -113,16 +66,6 @@ namespace Microsoft.Identity.Client.Extensions.Msal
             bool alreadyLoggedException = false;
             try
             {
-                // Guarantee that the version file exists so that we can know if it changes.
-                if (!File.Exists(VersionFilePath))
-                {
-                    WriteVersionFile();
-                }
-                else
-                {
-                    CacheLastReadVersion();
-                }
-
                 _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Reading Data");
                 byte[] fileData = ReadDataCore();
 
@@ -350,7 +293,6 @@ namespace Microsoft.Identity.Client.Extensions.Msal
             TryProcessFile(() =>
             {
                 File.WriteAllBytes(CacheFilePath, data);
-                WriteVersionFile();
             });
         }
 
@@ -372,8 +314,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal
                     _logger.TraceEvent(TraceEventType.Error, /*id*/ 0, $"Problem deleting the cache file '{e}'");
                 }
 
-                WriteVersionFile();
-                _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"After deleting the cache file. Last version token is '{_lastVersionToken}'");
+                _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"After deleting the cache file.");
             });
 
             if (SharedUtilities.IsMacPlatform())

--- a/tests/Microsoft.Identity.Client.Extensions.Adal.UnitTests/AdalCacheStorageTests.cs
+++ b/tests/Microsoft.Identity.Client.Extensions.Adal.UnitTests/AdalCacheStorageTests.cs
@@ -55,9 +55,7 @@ namespace Microsoft.Identity.Client.Extensions.Adal.UnitTests
         public void AdalNewStoreNoFile()
         {
             var store = new AdalCacheStorage(s_storageCreationProperties, logger: _logger);
-            Assert.IsTrue(store.HasChanged);
             Assert.IsFalse(store.ReadData().Any());
-            Assert.IsFalse(store.HasChanged);
         }
 
         [TestMethod]
@@ -80,18 +78,13 @@ namespace Microsoft.Identity.Client.Extensions.Adal.UnitTests
             byte[] data = { 2, 2, 3 };
             byte[] data2 = { 2, 2, 3, 4, 4 };
             store.WriteData(data);
-            Assert.IsFalse(store.HasChanged);
-            Enumerable.SequenceEqual(store.ReadData(), data);
+            Assert.IsTrue(Enumerable.SequenceEqual(store.ReadData(), data));
 
             store.WriteData(data);
-            Assert.IsFalse(store.HasChanged);
             store.WriteData(data2);
-            Assert.IsFalse(store.HasChanged);
             store.WriteData(data);
-            Assert.IsFalse(store.HasChanged);
             store.WriteData(data2);
-            Assert.IsFalse(store.HasChanged);
-            Enumerable.SequenceEqual(store.ReadData(), data2);
+            Assert.IsTrue(Enumerable.SequenceEqual(store.ReadData(), data2));
         }
 
         [TestMethod]
@@ -103,18 +96,12 @@ namespace Microsoft.Identity.Client.Extensions.Adal.UnitTests
 
             byte[] data = { 2, 2, 3 };
             store.WriteData(data);
-
-            Assert.IsFalse(store.HasChanged);
-            Assert.IsTrue(store2.HasChanged);
-
             store2.ReadData();
 
-            Enumerable.SequenceEqual(store.ReadData(), data);
+            Assert.IsTrue(Enumerable.SequenceEqual(store.ReadData(), data));
             Assert.IsTrue(File.Exists(CacheFilePath));
 
             store.Clear();
-            Assert.IsFalse(store.HasChanged);
-            Assert.IsTrue(store2.HasChanged);
 
             Assert.IsFalse(store.ReadData().Any());
             Assert.IsFalse(store2.ReadData().Any());

--- a/tests/Microsoft.Identity.Client.Extensions.Adal.UnitTests/AdalCacheTests.cs
+++ b/tests/Microsoft.Identity.Client.Extensions.Adal.UnitTests/AdalCacheTests.cs
@@ -32,49 +32,5 @@ namespace Microsoft.Identity.Client.Extensions.Adal.UnitTests
                 attribute2: new KeyValuePair<string, string>("AdalClientVersion", "1.0.0.0"));
             s_storageCreationProperties = builder.Build();
         }
-
-        [TestMethod]
-        public async Task ThreeRegisteredCachesRemainInSyncTestAsync()
-        {
-            if (File.Exists(s_storageCreationProperties.CacheFilePath))
-            {
-                File.Delete(s_storageCreationProperties.CacheFilePath);
-            }
-
-            string startString = "Something to start with";
-            var startBytes = ProtectedData.Protect(Encoding.UTF8.GetBytes(startString), optionalEntropy: null, scope: DataProtectionScope.CurrentUser);
-            await File.WriteAllBytesAsync(s_storageCreationProperties.CacheFilePath, startBytes).ConfigureAwait(true);
-
-            var storage = new AdalCacheStorage(s_storageCreationProperties, _logger);
-            var cache1 = new AdalCache(storage, _logger);
-            var cache2 = new AdalCache(storage, _logger);
-            var cache3 = new AdalCache(storage, _logger);
-
-            var storeVersion0 = storage.LastVersionToken;
-
-            var args1 = new TokenCacheNotificationArgs();
-            var args2 = new TokenCacheNotificationArgs();
-            var args3 = new TokenCacheNotificationArgs();
-
-            cache1.BeforeAccessNotification(args1);
-            cache1.HasStateChanged = true;
-            cache1.AfterAccessNotification(args1);
-
-            var storeVersion1 = storage.LastVersionToken;
-
-            Assert.AreNotEqual(storeVersion0, storeVersion1);
-
-            cache2.BeforeAccessNotification(args2);
-            cache2.AfterAccessNotification(args2);
-
-            cache3.BeforeAccessNotification(args3);
-            cache3.AfterAccessNotification(args3);
-
-            var storeVersion2 = storage.LastVersionToken;
-            Assert.AreEqual(storeVersion1, storeVersion2);
-
-            File.Delete(s_storageCreationProperties.CacheFilePath);
-            File.Delete(s_storageCreationProperties.CacheFilePath + ".version");
-        }
     }
 }

--- a/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/MsalCacheStorageTests.cs
+++ b/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/MsalCacheStorageTests.cs
@@ -56,9 +56,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
         public void MsalNewStoreNoFile()
         {
             var store = new MsalCacheStorage(s_storageCreationProperties, logger: _logger);
-            Assert.IsTrue(store.HasChanged);
             Assert.IsFalse(store.ReadData().Any());
-            Assert.IsFalse(store.HasChanged);
         }
 
         [TestMethod]
@@ -81,45 +79,32 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
             byte[] data = { 2, 2, 3 };
             byte[] data2 = { 2, 2, 3, 4, 4 };
             store.WriteData(data);
-            Assert.IsFalse(store.HasChanged);
-            Enumerable.SequenceEqual(store.ReadData(), data);
+            Assert.IsTrue(Enumerable.SequenceEqual(store.ReadData(), data));
 
             store.WriteData(data);
-            Assert.IsFalse(store.HasChanged);
             store.WriteData(data2);
-            Assert.IsFalse(store.HasChanged);
             store.WriteData(data);
-            Assert.IsFalse(store.HasChanged);
             store.WriteData(data2);
-            Assert.IsFalse(store.HasChanged);
-            Enumerable.SequenceEqual(store.ReadData(), data2);
+            Assert.IsTrue(Enumerable.SequenceEqual(store.ReadData(), data2));
         }
 
         [TestMethod]
         public void MsalTestClear()
         {
             var store = new MsalCacheStorage(s_storageCreationProperties, logger: _logger);
-            Assert.IsTrue(store.HasChanged);
             var tempData = store.ReadData();
-            Assert.IsFalse(store.HasChanged);
 
             var store2 = new MsalCacheStorage(s_storageCreationProperties, logger: _logger);
             Assert.IsNotNull(Exception<ArgumentNullException>(() => store.WriteData(null)));
 
             byte[] data = { 2, 2, 3 };
             store.WriteData(data);
-
-            Assert.IsFalse(store.HasChanged);
-            Assert.IsTrue(store2.HasChanged);
-
             store2.ReadData();
 
-            Enumerable.SequenceEqual(store.ReadData(), data);
+            Assert.IsTrue(Enumerable.SequenceEqual(store.ReadData(), data));
             Assert.IsTrue(File.Exists(CacheFilePath));
 
             store.Clear();
-            Assert.IsFalse(store.HasChanged);
-            Assert.IsTrue(store2.HasChanged);
 
             Assert.IsFalse(store.ReadData().Any());
             Assert.IsFalse(store2.ReadData().Any());


### PR DESCRIPTION
We found enough problems around cache invalidation, that it makes sense to simply read the cache every time we need it. This PR removes all checks for version-related code, and loads from disk every time.