### PR TITLE
update to msal40 with cache interaction changes

### DIFF
--- a/src/Microsoft.Identity.Client.Extensions.Msal/Microsoft.Identity.Client.Extensions.Msal.csproj
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/Microsoft.Identity.Client.Extensions.Msal.csproj
@@ -30,7 +30,7 @@
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetDesktop)'">

--- a/src/Microsoft.Identity.Client.Extensions.Msal/Providers/SharedTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/Providers/SharedTokenCacheProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -20,7 +20,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal.Providers
     /// </summary>
     public class SharedTokenCacheProvider : ITokenProvider
     {
-        private static readonly string CacheFilePath =
+        private static readonly string s_cacheFilePath =
             Path.Combine(SharedUtilities.GetUserRootDirectory(), "msal.cache");
         private readonly IPublicClientApplication _app;
         private readonly MsalCacheHelper _cacheHelper;
@@ -36,8 +36,8 @@ namespace Microsoft.Identity.Client.Extensions.Msal.Providers
             const string serviceName = "Microsoft.Developer.IdentityService";
             const string clientId = "04b07795-8ddb-461a-bbee-02f9e1bf7b46";
             var storageCreationPropertiesBuilder = new StorageCreationPropertiesBuilder(
-                Path.GetFileName(CacheFilePath),
-                Path.GetDirectoryName(CacheFilePath),
+                Path.GetFileName(s_cacheFilePath),
+                Path.GetDirectoryName(s_cacheFilePath),
                 clientId)
                 .WithMacKeyChain(serviceName: serviceName, accountName: "MSALCache")
                 .WithLinuxKeyring(

--- a/src/Microsoft.Identity.Client.Extensions.Web/Microsoft.Identity.Client.Extensions.Web.csproj
+++ b/src/Microsoft.Identity.Client.Extensions.Web/Microsoft.Identity.Client.Extensions.Web.csproj
@@ -43,6 +43,6 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Session/MsalAppSessionTokenCacheProvider.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Web/TokenCacheProviders/Session/MsalAppSessionTokenCacheProvider.cs
@@ -68,8 +68,6 @@ namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders.Session
             _apptokenCache.SetBeforeAccess(AppTokenCacheBeforeAccessNotification);
             _apptokenCache.SetAfterAccess(AppTokenCacheAfterAccessNotification);
             _apptokenCache.SetBeforeWrite(AppTokenCacheBeforeWriteNotification);
-
-            LoadAppTokenCacheFromSession();
         }
 
         /// <summary>
@@ -79,55 +77,6 @@ namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders.Session
         private void AppTokenCacheBeforeWriteNotification(TokenCacheNotificationArgs args)
         {
             // Since we are using a SessionCache ,whose methods are threads safe, we need not to do anything in this handler.
-        }
-
-        /// <summary>
-        /// Loads the application's tokens from session cache.
-        /// </summary>
-        private void LoadAppTokenCacheFromSession()
-        {
-            _httpContext.Session.LoadAsync().Wait();
-
-            s_sessionLock.EnterReadLock();
-            try
-            {
-                byte[] blob;
-                if (_httpContext.Session.TryGetValue(_appCacheId, out blob))
-                {
-                    Debug.WriteLine($"INFO: Deserializing session {_httpContext.Session.Id}, cacheId {_appCacheId}");
-                    _apptokenCache.DeserializeMsalV3(blob);
-                }
-                else
-                {
-                    Debug.WriteLine($"INFO: cacheId {_appCacheId} not found in session {_httpContext.Session.Id}");
-                }
-            }
-            finally
-            {
-                s_sessionLock.ExitReadLock();
-            }
-        }
-
-        /// <summary>
-        /// Persists the application token's to session cache.
-        /// </summary>
-        private void PersistAppTokenCache()
-        {
-            s_sessionLock.EnterWriteLock();
-
-            try
-            {
-                Debug.WriteLine($"INFO: Serializing session {_httpContext.Session.Id}, cacheId {_appCacheId}");
-
-                // Reflect changes in the persistent store
-                byte[] blob = _apptokenCache.SerializeMsalV3();
-                _httpContext.Session.Set(_appCacheId, blob);
-                _httpContext.Session.CommitAsync().Wait();
-            }
-            finally
-            {
-                s_sessionLock.ExitWriteLock();
-            }
         }
 
         /// <summary>
@@ -149,9 +98,6 @@ namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders.Session
             {
                 s_sessionLock.ExitWriteLock();
             }
-
-            // Nulls the currently deserialized instance
-            LoadAppTokenCacheFromSession();
         }
 
         /// <summary>
@@ -160,7 +106,26 @@ namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders.Session
         /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
         private void AppTokenCacheBeforeAccessNotification(TokenCacheNotificationArgs args)
         {
-            LoadAppTokenCacheFromSession();
+            _httpContext.Session.LoadAsync().Wait();
+
+            s_sessionLock.EnterReadLock();
+            try
+            {
+                byte[] blob;
+                if (_httpContext.Session.TryGetValue(_appCacheId, out blob))
+                {
+                    Debug.WriteLine($"INFO: Deserializing session {_httpContext.Session.Id}, cacheId {_appCacheId}");
+                    args.TokenCache.DeserializeMsalV3(blob);
+                }
+                else
+                {
+                    Debug.WriteLine($"INFO: cacheId {_appCacheId} not found in session {_httpContext.Session.Id}");
+                }
+            }
+            finally
+            {
+                s_sessionLock.ExitReadLock();
+            }
         }
 
         /// <summary>
@@ -172,7 +137,21 @@ namespace Microsoft.Identity.Client.Extensions.Web.TokenCacheProviders.Session
             // if the access operation resulted in a cache update
             if (args.HasStateChanged)
             {
-                PersistAppTokenCache();
+                s_sessionLock.EnterWriteLock();
+
+                try
+                {
+                    Debug.WriteLine($"INFO: Serializing session {_httpContext.Session.Id}, cacheId {_appCacheId}");
+
+                    // Reflect changes in the persistent store
+                    byte[] blob = args.TokenCache.SerializeMsalV3();
+                    _httpContext.Session.Set(_appCacheId, blob);
+                    _httpContext.Session.CommitAsync().Wait();
+                }
+                finally
+                {
+                    s_sessionLock.ExitWriteLock();
+                }
             }
         }
     }

--- a/tests/ManualTestApp/ManualTestApp.csproj
+++ b/tests/ManualTestApp/ManualTestApp.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.0.5" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/Microsoft.Identity.Client.Extensions.Msal.UnitTests.csproj
+++ b/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/Microsoft.Identity.Client.Extensions.Msal.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />

--- a/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/MockTokenCache.cs
+++ b/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/MockTokenCache.cs
@@ -4,13 +4,14 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Cache;
 
 #pragma warning disable CS0618 // Type or member is obsolete (CacheData)
 namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
 {
-    internal class MockTokenCache : ITokenCache
+    internal class MockTokenCache : ITokenCache, ITokenCacheSerializer
     {
         private TokenCacheCallback _beforeAccess;
         private TokenCacheCallback _afterAccess;
@@ -84,15 +85,21 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
             _afterAccess = afterAccess;
         }
 
+        public void SetAfterAccessAsync(Func<TokenCacheNotificationArgs, Task> afterAccess) => throw new NotImplementedException();
+
         public void SetBeforeAccess(TokenCacheCallback beforeAccess)
         {
             _beforeAccess = beforeAccess;
         }
 
+        public void SetBeforeAccessAsync(Func<TokenCacheNotificationArgs, Task> beforeAccess) => throw new NotImplementedException();
+
         public void SetBeforeWrite(TokenCacheCallback beforeWrite)
         {
             throw new NotImplementedException();
         }
+
+        public void SetBeforeWriteAsync(Func<TokenCacheNotificationArgs, Task> beforeWrite) => throw new NotImplementedException();
     }
 }
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/MsalCacheHelperTests.cs
+++ b/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/MsalCacheHelperTests.cs
@@ -64,10 +64,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
 
             var thread1 = new Thread(() =>
             {
-                var args = new TokenCacheNotificationArgs
-                {
-                    TokenCache = cache1
-                };
+                var args = new TokenCacheNotificationArgs(cache1, string.Empty, null, false);
 
                 helper1.BeforeAccessNotification(args);
                 resetEvent3.Set();
@@ -77,11 +74,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
 
             var thread2 = new Thread(() =>
             {
-                var args = new TokenCacheNotificationArgs
-                {
-                    TokenCache = cache2
-                };
-
+                var args = new TokenCacheNotificationArgs(cache2, string.Empty, null, false);
                 helper2.BeforeAccessNotification(args);
                 resetEvent4.Set();
                 resetEvent2.Wait();
@@ -142,28 +135,17 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
             helper.RegisterCache(cache2);
             helper.RegisterCache(cache3);
 
-            // One call from register
-            Assert.AreEqual(1, cache1.DeserializeMsalV3_MergeCache);
-            Assert.AreEqual(1, cache2.DeserializeMsalV3_MergeCache);
-            Assert.AreEqual(1, cache3.DeserializeMsalV3_MergeCache);
-            Assert.AreEqual(startString, cache1.LastDeserializedString);
-            Assert.AreEqual(startString, cache2.LastDeserializedString);
-            Assert.AreEqual(startString, cache3.LastDeserializedString);
+            // No calls at register
+            Assert.AreEqual(0, cache1.DeserializeMsalV3_MergeCache);
+            Assert.AreEqual(0, cache2.DeserializeMsalV3_MergeCache);
+            Assert.AreEqual(0, cache3.DeserializeMsalV3_MergeCache);
+            Assert.IsNull(cache1.LastDeserializedString);
+            Assert.IsNull(cache2.LastDeserializedString);
+            Assert.IsNull(cache3.LastDeserializedString);
 
-            var args1 = new TokenCacheNotificationArgs
-            {
-                TokenCache = cache1
-            };
-
-            var args2 = new TokenCacheNotificationArgs
-            {
-                TokenCache = cache2
-            };
-
-            var args3 = new TokenCacheNotificationArgs
-            {
-                TokenCache = cache3
-            };
+            var args1 = new TokenCacheNotificationArgs(cache1, string.Empty, null, false);
+            var args2 = new TokenCacheNotificationArgs(cache2, string.Empty, null, false);
+            var args3 = new TokenCacheNotificationArgs(cache3, string.Empty, null, false);
 
             var changedString = "Hey look, the file changed";
 
@@ -178,10 +160,9 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
             helper.BeforeAccessNotification(args3);
             helper.AfterAccessNotification(args3);
 
-            // Still only one call from register
-            Assert.AreEqual(1, cache1.DeserializeMsalV3_MergeCache);
-            Assert.AreEqual(1, cache2.DeserializeMsalV3_MergeCache);
-            Assert.AreEqual(1, cache3.DeserializeMsalV3_MergeCache);
+            Assert.AreEqual(0, cache1.DeserializeMsalV3_MergeCache);
+            Assert.AreEqual(0, cache2.DeserializeMsalV3_MergeCache);
+            Assert.AreEqual(0, cache3.DeserializeMsalV3_MergeCache);
 
             // Cache 1 should deserialize, in spite of just writing, just in case another process wrote in the intervening time
             Assert.AreEqual(1, cache1.DeserializeMsalV3_ClearCache);

--- a/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/Providers/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/Providers/ManagedIdentityTests.cs
@@ -349,7 +349,10 @@ namespace Microsoft.Identity.Client.Extensions.Msal.Providers
         {
             var responder = Responders.FirstOrDefault(i => i.Matcher(request, i.State));
             if (responder == null)
+            {
                 Assert.Fail($"responder was not found that matched the request: {request}");
+            }
+
             return Task.FromResult(responder.MockResponse(request, responder.State));
         }
 

--- a/tests/Microsoft.Identity.Client.Extensions.Web.UnitTests/Microsoft.Identity.Client.Extensions.Web.UnitTests.csproj
+++ b/tests/Microsoft.Identity.Client.Extensions.Web.UnitTests/Microsoft.Identity.Client.Extensions.Web.UnitTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />


### PR DESCRIPTION
Cache serialization with MSAL.NET 4.0 now only happens via TokenNotificationArgs due to locking updates introduced with async token cache callbacks.  So the usage semantics needed to be cleaned up a bit.