### PR TITLE
fix null argument exception when logger is not provided

### DIFF
--- a/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheStorage.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheStorage.cs
@@ -39,8 +39,8 @@ namespace Microsoft.Identity.Client.Extensions.Msal
         public MsalCacheStorage(StorageCreationProperties creationProperties, TraceSource logger = null)
         {
             _creationProperties = creationProperties;
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Initialized '{nameof(MsalCacheStorage)}'");
+            _logger = logger ?? s_staticLogger.Value;
+            _logger.TraceEvent(TraceEventType.Information, /*id*/ 0, $"Initialized '{nameof(MsalCacheStorage)}'");
         }
 
         /// <summary>

--- a/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/Providers/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/Providers/ManagedIdentityTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal.Providers
     public class ManagedIdentityTests
     {
         [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification = "Fake Secret")]
-        private const string AccessToken = "abcdefg"; 
+        private const string AccessToken = "abcdefg";
         private const string RefreshToken = "hijklmn";
         private const string ExpiresOn = "1506484173";
         private const string AzureManagementVMManagedIdentityJson = @"{
@@ -61,6 +61,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal.Providers
             var st = DateTime.Now;
             Assert.IsFalse(await probe.IsAvailableAsync().ConfigureAwait(false));
             Assert.IsTrue(DateTime.Now - st < TimeSpan.FromMilliseconds(800), "should take less than 800 milliseconds");
+            VisualStudio.TestTools.UnitTesting.Logging.Logger.LogMessage((DateTime.Now - st).ToString());
         }
 
         [TestMethod]

--- a/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/Providers/SharedTokenCacheProviderTest.cs
+++ b/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/Providers/SharedTokenCacheProviderTest.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Client.Extensions.Msal.Providers
+{
+    [TestClass]
+    public class SharedTokenCacheProviderTest
+    {
+        private StorageCreationPropertiesBuilder _builder;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            var tmpFilePath = Path.GetTempFileName();
+            _builder = new StorageCreationPropertiesBuilder(
+                    Path.GetFileName(tmpFilePath),
+                    Path.GetDirectoryName(tmpFilePath),
+                    "1234")
+                .WithMacKeyChain(serviceName: "testFoo", accountName: "accountName")
+                .WithLinuxKeyring(
+                    schemaName: "msal.cache",
+                    collection: "default",
+                    secretLabel: "MSALCache",
+                    attribute1: new KeyValuePair<string, string>("MsalClientID", "testFoo"),
+                    attribute2: new KeyValuePair<string, string>("MsalClientVersion", "1.0.0.0"));
+        }
+
+        [TestMethod]
+        [TestCategory("SharedTokenCacheProviderTests")]
+        public async Task ShouldNotBeAvailableWithoutIdentitiesAsync()
+        {
+            var provider = new SharedTokenCacheProvider(_builder);
+            Assert.IsFalse(await provider.IsAvailableAsync().ConfigureAwait(false));
+        }
+    }
+}


### PR DESCRIPTION
I ran across an exception when the SharedCacheProvider builds a `MsalCacheStorage` with a null logger. In the case when the logger is null, it seems appropriate to use the static logger rather than throwing an exception.