### PR TITLE
Minor cleanup of global.json and test app change

### DIFF
--- a/MsalNetExt.sln
+++ b/MsalNetExt.sln
@@ -23,6 +23,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleTestForTokenProvider
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAppTestWithAzureSDK", "tests\WebAppTestWithAzureSDK\WebAppTestWithAzureSDK.csproj", "{2F233ADD-658B-4E3F-86CA-4E031CAD97A5}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{D6543F66-0A93-4D0B-9A31-11A57C22BC99}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Shared\Shared.projitems*{f575599f-41ad-4cdd-b0ad-3b659a43ee84}*SharedItemsImports = 13

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-    "sdk": { "version": "2.2.203" },
-    "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "1.6.61"
-    }
-}

--- a/src/Microsoft.Identity.Client.Extensions.Msal/Microsoft.Identity.Client.Extensions.Msal.csproj
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/Microsoft.Identity.Client.Extensions.Msal.csproj
@@ -35,6 +35,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetDesktop)'">
     <Compile Remove="Providers/*.cs" />
+    <None Include="Providers/*.cs" />
     <Reference Include="System.Security" />
   </ItemGroup>
 

--- a/tests/ManualTestApp/Program.cs
+++ b/tests/ManualTestApp/Program.cs
@@ -10,6 +10,9 @@ using Microsoft.Identity.Client.Extensions.Msal;
 
 namespace ManualTestApp
 {
+
+    // Example usage:
+    // login-msal https://graph.microsoft.com/ 49f548d0-12b7-4169-a390-bb5304d24462 https://login.microsoftonline.com true 1d18b3b0-251b-4714-a02a-9956cec86c2d msal.ext.cache msal_exp
     class Program
     {
         private static MsalCacheHelper s_helper;
@@ -111,7 +114,8 @@ namespace ManualTestApp
                     };
                 }
 
-                var builder = app.AcquireTokenWithDeviceCode(scopes, Utilities.DeviceCodeCallbackAsync);
+                //var builder = app.AcquireTokenWithDeviceCode(scopes, Utilities.DeviceCodeCallbackAsync);
+                var builder = app.AcquireTokenInteractive(scopes);
                 var authResult = await builder.ExecuteAsync().ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/tests/ManualTestApp/Utilities.cs
+++ b/tests/ManualTestApp/Utilities.cs
@@ -35,7 +35,8 @@ namespace ManualTestApp
             Console.WriteLine($"GetPublicClient for authority: '{authority}' ValidateAuthority: '{validateAuthority}'");
 
             Uri authorityUri = new Uri(authority);
-            var appBuilder = PublicClientApplicationBuilder.Create(clientId).WithAuthority(authorityUri, validateAuthority);
+            var appBuilder = PublicClientApplicationBuilder.Create(clientId).WithAuthority(authorityUri, validateAuthority)
+                .WithRedirectUri("http://localhost");
             var app = appBuilder.Build();
             Console.WriteLine($"Built public client");
 


### PR DESCRIPTION
I deleted global.json because: 

- it specified a version of msbuild.sdk.extras, but this project does not use the extras (it's only needed for adding xamarin and uwp targets)
- it specified a version of .net core SDK, which is a somewhat old, but the project builds fine with any SDK