### PR TITLE
Add a VerifyPersistence API to the cache helper

### DIFF
--- a/src/Microsoft.Identity.Client.Extensions.Msal/ICacheAccessor.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/ICacheAccessor.cs
@@ -11,10 +11,27 @@ namespace Microsoft.Identity.Client.Extensions.Msal
 {
     internal interface ICacheAccessor
     {
+        /// <summary>
+        /// Deletes the cache
+        /// </summary>
         void Clear();
 
+        /// <summary>
+        /// Reads the cache
+        /// </summary>
+        /// <returns>Unprotected cache</returns>
         byte[] Read();
 
+        /// <summary>
+        /// Writes the cache 
+        /// </summary>
+        /// <param name="data">Unprotected cache</param>
         void Write(byte[] data);
+
+        /// <summary>
+        /// Create an ICacheAccessor that can be used for validating persistence. This must
+        /// be similar but not identical to the current accessor, so that to avoid overwriting an actual token cache
+        /// </summary>
+        ICacheAccessor CreateForPersistenceValidation();
     }
 }

--- a/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheHelper.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheHelper.cs
@@ -387,8 +387,10 @@ namespace Microsoft.Identity.Client.Extensions.Msal
         }
 
         /// <summary>
-        /// 
+        /// Performs a write -> read -> clear using the underlying persistence mechanism and
+        /// throws an <see cref="MsalCachePersistenceException"/> if something goes wrong.
         /// </summary>
+        /// <remarks>Does not overwrite the token cache. Should never fail on Windows and Mac where the cache accessors are guaranteed to exist by the OS.</remarks>
         public void VerifyPersistence()
         {
             _store.VerifyPersistence();

--- a/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheHelper.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheHelper.cs
@@ -17,6 +17,17 @@ namespace Microsoft.Identity.Client.Extensions.Msal
     public class MsalCacheHelper
     {
         /// <summary>
+        /// The name of the Default KeyRing collection. Secrets stored in this collection are persisted to disk
+        /// </summary>
+        public const string LinuxKeyRingDefaultCollection = "default";
+
+        /// <summary>
+        /// The name of the Session KeyRing collection. Secrets stored in this collection are not persisted to disk, but
+        /// will be avaiable for the duration of the user session.
+        /// </summary>
+        public const string LinuxKeyRingSessionCollection = "session";
+
+        /// <summary>
         /// A default logger for use if the user doesn't want to provide their own.
         /// </summary>
         private static readonly Lazy<TraceSourceLogger> s_staticLogger = new Lazy<TraceSourceLogger>(() =>
@@ -42,7 +53,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal
         /// <summary>
         /// Storage that handles the storing of the adal cache file on disk. Internal for testing.
         /// </summary>
-        internal readonly MsalCacheStorage _store;
+        private readonly MsalCacheStorage _store;
 
         /// <summary>
         /// Logger to log events to.
@@ -373,6 +384,14 @@ namespace Microsoft.Identity.Client.Extensions.Msal
                 localDispose?.Dispose();
                 _logger.LogInformation($"Released lock");
             }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void VerifyPersistence()
+        {
+            _store.VerifyPersistence();
         }
     }
 }

--- a/src/Microsoft.Identity.Client.Extensions.Msal/MsalCachePersistenceException.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/MsalCachePersistenceException.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.Identity.Client.Extensions.Msal
+{
+    /// <summary>
+    /// Exception that results when trying to persist data to the underlying OS mechanism (KeyRing, KeyChain, DPAPI)
+    /// Inspect inner exception for details.
+    /// </summary>
+    public class MsalCachePersistenceException : Exception
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public MsalCachePersistenceException()
+        {
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="message"></param>
+        public MsalCachePersistenceException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="innerException"></param>
+        public MsalCachePersistenceException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="info"></param>
+        /// <param name="context"></param>
+        protected MsalCachePersistenceException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheStorage.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheStorage.cs
@@ -187,19 +187,18 @@ namespace Microsoft.Identity.Client.Extensions.Msal
             }
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
         public void VerifyPersistence()
         {
-
             try
             {
+                // do not use the _cacheAccessor for writing dummy data, as it might overwrite an actual token cache
+                var persitenceValidatationAccessor = _cacheAccessor.CreateForPersistenceValidation();
+
                 _logger.LogInformation($"[Verify Persistence] Writing Data ");
-                _cacheAccessor.Write(Encoding.UTF8.GetBytes(PersistenceValidationDummyData));
+                persitenceValidatationAccessor.Write(Encoding.UTF8.GetBytes(PersistenceValidationDummyData));
 
                 _logger.LogInformation($"[Verify Persistence] Reading Data ");
-                var data = _cacheAccessor.Read();
+                var data = persitenceValidatationAccessor.Read();
 
                 if (data == null || data.Length == 0)
                 {
@@ -217,7 +216,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal
                 }
 
                 _logger.LogInformation($"[Verify Persistence] Clearing data");
-                _cacheAccessor.Clear();
+                persitenceValidatationAccessor.Clear();
             }
             catch (Exception ex) when (!(ex is MsalCachePersistenceException))
             {

--- a/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheStorage.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheStorage.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.Serialization;
 using System.Threading;
 
 namespace Microsoft.Identity.Client.Extensions.Msal
@@ -12,7 +13,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal
     /// <summary>
     /// Persist cache to file
     /// </summary>
-    public class MsalCacheStorage 
+    internal class MsalCacheStorage 
     {
         private readonly TraceSourceLogger _logger;
 
@@ -27,18 +28,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal
         private static readonly Lazy<TraceSourceLogger> s_staticLogger = new Lazy<TraceSourceLogger>(() =>
         {
             return new TraceSourceLogger(EnvUtils.GetNewTraceSource(nameof(MsalCacheHelper) + "Singleton"));
-        });
-
-        /// <summary>
-        /// The name of the Default KeyRing collection. Secrets stored in this collection are persisted to disk
-        /// </summary>
-        public const string LinuxKeyRingDefaultCollection = "default";
-
-        /// <summary>
-        /// The name of the Session KeyRing collection. Secrets stored in this collection are not persisted to disk, but
-        /// will be avaiable for the duration of the user session.
-        /// </summary>
-        public const string LinuxKeyRingSessionCollection = "session";
+        });        
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MsalCacheStorage"/> class.
@@ -184,6 +174,24 @@ namespace Microsoft.Identity.Client.Extensions.Msal
             {
                 _logger.LogError($"An exception was encountered while clearing data from {nameof(MsalCacheStorage)} : {e}");
             }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void VerifyPersistence()
+        {
+            try
+            {
+                _logger.LogInformation($"[Verify Persistence] Reading Data ");
+                var data = _cacheAccessor.Read();
+                _logger.LogInformation($"[Verify Persistence] Got '{data?.Length}' bytes from file storage");
+            }            
+            catch(Exception ex)
+            {
+                throw new MsalCachePersistenceException("Persistence check failed. Inspect inner exception for details", ex);
+            }
+
         }
     }
 }

--- a/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheStorage.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheStorage.cs
@@ -22,6 +22,9 @@ namespace Microsoft.Identity.Client.Extensions.Msal
 
         internal StorageCreationProperties CreationProperties { get; }
 
+        internal const string PersistenceValidationDummyData = "dummy_data";
+
+
 
         /// <summary>
         /// A default logger for use if the user doesn't want to provide their own.
@@ -189,12 +192,11 @@ namespace Microsoft.Identity.Client.Extensions.Msal
         /// </summary>
         public void VerifyPersistence()
         {
-            const string DummyData = "dummy_data";
 
             try
             {
                 _logger.LogInformation($"[Verify Persistence] Writing Data ");
-                _cacheAccessor.Write(Encoding.UTF8.GetBytes(DummyData));
+                _cacheAccessor.Write(Encoding.UTF8.GetBytes(PersistenceValidationDummyData));
 
                 _logger.LogInformation($"[Verify Persistence] Reading Data ");
                 var data = _cacheAccessor.Read();
@@ -207,10 +209,10 @@ namespace Microsoft.Identity.Client.Extensions.Msal
                 }
 
                 string dataRead = Encoding.UTF8.GetString(data);
-                if (!string.Equals(DummyData, dataRead, StringComparison.Ordinal))
+                if (!string.Equals(PersistenceValidationDummyData, dataRead, StringComparison.Ordinal))
                 {
                     throw new MsalCachePersistenceException(
-                        $"Persistence check failed. Data written {DummyData} is different from data read {dataRead}");
+                        $"Persistence check failed. Data written {PersistenceValidationDummyData} is different from data read {dataRead}");
 
                 }
 

--- a/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheStorage.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheStorage.cs
@@ -204,7 +204,6 @@ namespace Microsoft.Identity.Client.Extensions.Msal
                     throw new MsalCachePersistenceException(
                         "Persistence check failed. Data written could not be read. " +
                         "Possible cause: on Linux, LibSecret is installed by D-Bus isn't running because it cannot be started over SSH.");
-
                 }
 
                 string dataRead = Encoding.UTF8.GetString(data);
@@ -218,7 +217,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal
                 _logger.LogInformation($"[Verify Persistence] Clearing data");
                 _cacheAccessor.Clear();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!(ex is MsalCachePersistenceException))
             {
                 throw new MsalCachePersistenceException("Persistence check failed. Inspect inner exception for details", ex);
             }

--- a/src/Microsoft.Identity.Client.Extensions.Msal/Os/Linux/CacheAccessorLinux.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/Os/Linux/CacheAccessorLinux.cs
@@ -9,22 +9,85 @@ namespace Microsoft.Identity.Client.Extensions.Msal
 {
     internal class CacheAccessorLinux : ICacheAccessor
     {
-        private readonly StorageCreationProperties _creationProperties;
+        //private readonly StorageCreationProperties _creationProperties;
         private readonly TraceSourceLogger _logger;
         private IntPtr _libsecretSchema = IntPtr.Zero;
 
-        public CacheAccessorLinux(StorageCreationProperties creationProperties, TraceSourceLogger logger)
+        private readonly string _cacheFilePath;
+        private readonly string _keyringCollection;
+        private readonly string _keyringSchemaName;
+        private readonly string _keyringSecretLabel;
+        private readonly string _attributeKey1;
+        private readonly string _attributeValue1;
+        private readonly string _attributeKey2;
+        private readonly string _attributeValue2;
+        private readonly TraceSourceLogger _actualLogger;
+
+        public CacheAccessorLinux(
+            string cacheFilePath,
+            string keyringCollection,
+            string keyringSchemaName,
+            string keyringSecretLabel,
+            string attributeKey1,
+            string attributeValue1,
+            string attributeKey2,
+            string attributeValue2,
+            TraceSourceLogger logger)
         {
-            _creationProperties = creationProperties ?? throw new ArgumentNullException(nameof(creationProperties));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            if (string.IsNullOrWhiteSpace(cacheFilePath))
+            {
+                throw new ArgumentNullException(nameof(cacheFilePath));
+            }
+
+            if (string.IsNullOrWhiteSpace(attributeKey1))
+            {
+                throw new ArgumentNullException(nameof(attributeKey1));
+            }
+
+            if (string.IsNullOrWhiteSpace(attributeValue1))
+            {
+                throw new ArgumentNullException(nameof(attributeValue1));
+            }
+
+            if (string.IsNullOrWhiteSpace(attributeKey2))
+            {
+                throw new ArgumentNullException(nameof(attributeKey2));
+            }
+
+            if (string.IsNullOrWhiteSpace(attributeValue2))
+            {
+                throw new ArgumentNullException(nameof(attributeValue2));
+            }
+
+            _cacheFilePath = cacheFilePath;
+            _keyringCollection = keyringCollection;
+            _keyringSchemaName = keyringSchemaName;
+            _keyringSecretLabel = keyringSecretLabel;
+            _attributeKey1 = attributeKey1;
+            _attributeValue1 = attributeValue1;
+            _attributeKey2 = attributeKey2;
+            _attributeValue2 = attributeValue2;
+            _actualLogger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public ICacheAccessor CreateForPersistenceValidation()
+        {
+            return new CacheAccessorLinux(
+                _cacheFilePath,
+                _keyringCollection,
+                _keyringSchemaName,
+                "MSAL Test",
+                _attributeKey1, "test",
+                _attributeKey2, "test",
+                _logger);
         }
 
         public void Clear()
         {
             _logger.LogInformation("Clearing cache");
-            FileIOWithRetries.DeleteCacheFile(_creationProperties.CacheFilePath, _logger);
+            FileIOWithRetries.DeleteCacheFile(_cacheFilePath, _logger);
 
-            _logger.LogInformation($"Before deletring secret from linux keyring");
+            _logger.LogInformation($"Before deleting secret from Linux keyring");
 
             IntPtr error = IntPtr.Zero;
 
@@ -32,10 +95,10 @@ namespace Microsoft.Identity.Client.Extensions.Msal
                 schema: GetLibsecretSchema(),
                 cancellable: IntPtr.Zero,
                 error: out error,
-                attribute1Type: _creationProperties.KeyringAttribute1.Key,
-                attribute1Value: _creationProperties.KeyringAttribute1.Value,
-                attribute2Type: _creationProperties.KeyringAttribute2.Key,
-                attribute2Value: _creationProperties.KeyringAttribute2.Value,
+                attribute1Type: _attributeKey1,
+                attribute1Value: _attributeValue1,
+                attribute2Type: _attributeKey2,
+                attribute2Value: _attributeValue2,
                 end: IntPtr.Zero);
 
             if (error != IntPtr.Zero)
@@ -54,6 +117,8 @@ namespace Microsoft.Identity.Client.Extensions.Msal
             _logger.LogInformation("After deleting secret from linux keyring");
         }
 
+
+
         public byte[] Read()
         {
             _logger.LogInformation("ReadDataCore");
@@ -68,10 +133,10 @@ namespace Microsoft.Identity.Client.Extensions.Msal
                 schema: GetLibsecretSchema(),
                 cancellable: IntPtr.Zero,
                 error: out error,
-                attribute1Type: _creationProperties.KeyringAttribute1.Key,
-                attribute1Value: _creationProperties.KeyringAttribute1.Value,
-                attribute2Type: _creationProperties.KeyringAttribute2.Key,
-                attribute2Value: _creationProperties.KeyringAttribute2.Value,
+                attribute1Type: _attributeKey1,
+                attribute1Value: _attributeValue1,
+                attribute2Type: _attributeKey2,
+                attribute2Value: _attributeValue2,
                 end: IntPtr.Zero);
 
             if (error != IntPtr.Zero)
@@ -108,15 +173,15 @@ namespace Microsoft.Identity.Client.Extensions.Msal
 
             Libsecret.secret_password_store_sync(
                 schema: GetLibsecretSchema(),
-                collection: _creationProperties.KeyringCollection,
-                label: _creationProperties.KeyringSecretLabel,
+                collection: _keyringCollection,
+                label: _keyringSecretLabel,
                 password: Convert.ToBase64String(data),
                 cancellable: IntPtr.Zero,
                 error: out error,
-                attribute1Type: _creationProperties.KeyringAttribute1.Key,
-                attribute1Value: _creationProperties.KeyringAttribute1.Value,
-                attribute2Type: _creationProperties.KeyringAttribute2.Key,
-                attribute2Value: _creationProperties.KeyringAttribute2.Value,
+                attribute1Type: _attributeKey1,
+                attribute1Value: _attributeValue1,
+                attribute2Type: _attributeKey2,
+                attribute2Value: _attributeValue2,
                 end: IntPtr.Zero);
 
             if (error != IntPtr.Zero)
@@ -135,10 +200,10 @@ namespace Microsoft.Identity.Client.Extensions.Msal
             _logger.LogInformation("After saving to linux keyring");
 
             // Change data to 1 byte so we can write it to the cache file to update the last write time using the same write code used for windows.
-            FileIOWithRetries.WriteDataToFile(_creationProperties.CacheFilePath, new byte[] { 1 }, _logger);
+            FileIOWithRetries.WriteDataToFile(_cacheFilePath, new byte[] { 1 }, _logger);
         }
 
-        
+
         private IntPtr GetLibsecretSchema()
         {
             if (_libsecretSchema == IntPtr.Zero)
@@ -146,11 +211,11 @@ namespace Microsoft.Identity.Client.Extensions.Msal
                 _logger.LogInformation("Before creating libsecret schema");
 
                 _libsecretSchema = Libsecret.secret_schema_new(
-                    name: _creationProperties.KeyringSchemaName,
+                    name: _keyringSchemaName,
                     flags: (int)Libsecret.SecretSchemaFlags.SECRET_SCHEMA_DONT_MATCH_NAME,
-                    attribute1: _creationProperties.KeyringAttribute1.Key,
+                    attribute1: _attributeKey1,
                     attribute1Type: (int)Libsecret.SecretSchemaAttributeType.SECRET_SCHEMA_ATTRIBUTE_STRING,
-                    attribute2: _creationProperties.KeyringAttribute2.Key,
+                    attribute2: _attributeKey2,
                     attribute2Type: (int)Libsecret.SecretSchemaAttributeType.SECRET_SCHEMA_ATTRIBUTE_STRING,
                     end: IntPtr.Zero);
 

--- a/src/Microsoft.Identity.Client.Extensions.Msal/Os/Linux/CacheAccessorLinux.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/Os/Linux/CacheAccessorLinux.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Identity.Client.Extensions.Msal
 {
     internal class CacheAccessorLinux : ICacheAccessor
     {
-        //private readonly StorageCreationProperties _creationProperties;
         private readonly TraceSourceLogger _logger;
         private IntPtr _libsecretSchema = IntPtr.Zero;
 
@@ -21,7 +20,6 @@ namespace Microsoft.Identity.Client.Extensions.Msal
         private readonly string _attributeValue1;
         private readonly string _attributeKey2;
         private readonly string _attributeValue2;
-        private readonly TraceSourceLogger _actualLogger;
 
         public CacheAccessorLinux(
             string cacheFilePath,
@@ -67,7 +65,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal
             _attributeValue1 = attributeValue1;
             _attributeKey2 = attributeKey2;
             _attributeValue2 = attributeValue2;
-            _actualLogger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public ICacheAccessor CreateForPersistenceValidation()

--- a/src/Microsoft.Identity.Client.Extensions.Msal/Os/Mac/CacheAccessorMac.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/Os/Mac/CacheAccessorMac.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal
             _logger.LogInformation("After delete mac keychain");
         }
 
+       
         public byte[] Read()
         {
             _logger.LogInformation("ReadDataCore");
@@ -69,5 +70,15 @@ namespace Microsoft.Identity.Client.Extensions.Msal
             // Change data to 1 byte so we can write it to the cache file to update the last write time using the same write code used for windows.
             FileIOWithRetries.WriteDataToFile(_cacheFilePath, new byte[] { 1 }, _logger);
         }
+
+        public ICacheAccessor CreateForPersistenceValidation()
+        {
+            return new CacheAccessorMac(
+                _cacheFilePath + ".test",
+                _keyChainServiceName + "test",
+                _keyChainAccountName + "test",
+                _logger);
+        }
+
     }
 }

--- a/src/Microsoft.Identity.Client.Extensions.Msal/Os/Windows/CacheAccessorWindows.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/Os/Windows/CacheAccessorWindows.cs
@@ -24,6 +24,11 @@ namespace Microsoft.Identity.Client.Extensions.Msal
             FileIOWithRetries.DeleteCacheFile(_cacheFilePath, _logger);
         }
 
+        public ICacheAccessor CreateForPersistenceValidation()
+        {
+            return new CacheAccessorWindows(_cacheFilePath + ".test", _logger);
+        }
+
         public byte[] Read()
         {
             _logger.LogInformation("ReadDataCore");

--- a/tests/ManualTestApp/Config.cs
+++ b/tests/ManualTestApp/Config.cs
@@ -25,7 +25,7 @@ namespace ManualTestApp
         public const string KeyChainAccountName = "msal_account";
 
         public const string LinuxKeyRingSchema = "com.contoso.devtools.tokencache";
-        public const string LinuxKeyRingCollection = MsalCacheStorage.LinuxKeyRingDefaultCollection;
+        public const string LinuxKeyRingCollection = MsalCacheHelper.LinuxKeyRingDefaultCollection;
         public const string LinuxKeyRingLabel = "MSAL token cache for all Contoso dev tool apps.";
         public static readonly KeyValuePair<string, string> LinuxKeyRingAttr1 = new KeyValuePair<string, string>("Version", "1");
         public static readonly KeyValuePair<string, string> LinuxKeyRingAttr2 = new KeyValuePair<string, string>("ProductGroup", "MyApps");

--- a/tests/ManualTestApp/Config.cs
+++ b/tests/ManualTestApp/Config.cs
@@ -19,7 +19,7 @@ namespace ManualTestApp
 
         // Cache settings
         public const string CacheFileName = "msal_cache.dat";
-        public const string CacheDir = "MSAL_CACHE";
+        public readonly static string CacheDir = MsalCacheHelper.UserRootDirectory;
 
         public const string KeyChainServiceName = "msal_service";
         public const string KeyChainAccountName = "msal_account";

--- a/tests/ManualTestApp/Program.cs
+++ b/tests/ManualTestApp/Program.cs
@@ -250,7 +250,7 @@ namespace ManualTestApp
             catch (MsalCachePersistenceException ex)
             {
                 Console.WriteLine("WARNING: Cannot persist the token cache. Tokens will be held in memory only.");
-                Console.WriteLine($"Detailed error:  {ex.Message}");
+                Console.WriteLine($"Detailed error:  {ex}");
             }
         }
     }

--- a/tests/ManualTestApp/Program.cs
+++ b/tests/ManualTestApp/Program.cs
@@ -249,8 +249,12 @@ namespace ManualTestApp
             }
             catch (MsalCachePersistenceException ex)
             {
+                Console.BackgroundColor = ConsoleColor.Red;
+
                 Console.WriteLine("WARNING: Cannot persist the token cache. Tokens will be held in memory only.");
                 Console.WriteLine($"Detailed error:  {ex}");
+
+                Console.ResetColor();
             }
         }
     }

--- a/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/AssertException.cs
+++ b/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/AssertException.cs
@@ -1,0 +1,243 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
+{
+    public static class AssertException
+    {
+        public static void DoesNotThrow(Action testCode)
+        {
+            var ex = Recorder.Exception<Exception>(testCode);
+            if (ex != null)
+            {
+                throw new AssertFailedException("DoesNotThrow failed.", ex);
+            }
+        }
+
+        public static void DoesNotThrow(Func<object> testCode)
+        {
+            var ex = Recorder.Exception<Exception>(testCode);
+            if (ex != null)
+            {
+                throw new AssertFailedException("DoesNotThrow failed.", ex);
+            }
+        }
+
+        public static TException Throws<TException>(Action testCode)
+             where TException : Exception
+        {
+            return Throws<TException>(testCode, false);
+        }
+
+        public static TException Throws<TException>(Action testCode, bool allowDerived)
+             where TException : Exception
+        {
+            var exception = Recorder.Exception<TException>(testCode);
+
+            if (exception == null)
+            {
+                throw new AssertFailedException("AssertExtensions.Throws failed. No exception occurred.");
+            }
+
+            CheckExceptionType<TException>(exception, allowDerived);
+
+            return exception;
+        }
+
+        public static TException Throws<TException>(Func<object> testCode)
+            where TException : Exception
+        {
+            return Throws<TException>(testCode, false);
+        }
+
+        public static TException Throws<TException>(Func<object> testCode, bool allowDerived)
+            where TException : Exception
+        {
+            var exception = Recorder.Exception<TException>(testCode);
+
+            if (exception == null)
+            {
+                throw new AssertFailedException("AssertExtensions.Throws failed. No exception occurred.");
+            }
+
+            CheckExceptionType<TException>(exception, allowDerived);
+
+            return exception;
+        }
+
+        public static async Task<T> TaskThrowsAsync<T>(Func<Task> testCode, bool allowDerived = false)
+            where T : Exception
+        {
+            Exception exception = null;
+            try
+            {
+                await testCode().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            if (exception == null)
+            {
+                throw new AssertFailedException("AssertExtensions.TaskThrowsAsync failed. No exception occurred.");
+            }
+
+            if (exception is AggregateException aggEx)
+            {
+                if (aggEx.InnerException.GetType() == typeof(AssertFailedException))
+                {
+                    throw aggEx.InnerException;
+                }
+
+                var exceptionsMatching = aggEx.InnerExceptions.OfType<T>().ToList();
+
+                if (!exceptionsMatching.Any())
+                {
+                    ThrowAssertFailedForExceptionMismatch(typeof(T), exception);
+                }
+
+                return exceptionsMatching.First();
+            }
+
+            CheckExceptionType<T>(exception, allowDerived);
+
+            return (exception as T);
+        }
+
+        public static void TaskDoesNotThrow(Func<Task> testCode)
+        {
+            var exception = Recorder.Exception(() => testCode().Wait());
+
+            if (exception == null)
+            {
+                return;
+            }
+
+            throw new AssertFailedException(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    "AssertExtensions.TaskDoesNotThrow failed. Incorrect exception {0} occurred.",
+                    exception.GetType().Name),
+                exception);
+        }
+
+        public static void TaskDoesNotThrow<T>(Func<Task> testCode) where T : Exception
+        {
+            var exception = Recorder.Exception<AggregateException>(() => testCode().Wait());
+
+            if (exception == null)
+            {
+                return;
+            }
+
+            var exceptionsMatching = exception.InnerExceptions.OfType<T>().ToList();
+
+            if (!exceptionsMatching.Any())
+            {
+                return;
+            }
+
+            ThrowAssertFailedForExceptionMismatch(typeof(T), exception);
+        }
+
+        private static void CheckExceptionType<TException>(Exception actualException, bool allowDerived)
+        {
+            Type expectedType = typeof(TException);
+
+            string message = string.Format(
+                CultureInfo.CurrentCulture,
+                "Checking exception:{0}\tType:{1}{0}\tToString: {2}{0}",
+                Environment.NewLine,
+                actualException.GetType().FullName,
+                actualException.ToString());
+
+            Debug.WriteLine(message);
+
+            if (allowDerived)
+            {
+                if (!(actualException is TException))
+                {
+                    ThrowAssertFailedForExceptionMismatch(expectedType, actualException);
+                }
+            }
+            else
+            {
+                if (!expectedType.Equals(actualException.GetType()))
+                {
+                    ThrowAssertFailedForExceptionMismatch(expectedType, actualException);
+                }
+            }
+        }
+
+        private static void ThrowAssertFailedForExceptionMismatch(Type expectedExceptionType, Exception actualException)
+        {
+            throw new AssertFailedException(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    "Exception types do not match. Expected: {0}  Actual: {1}",
+                    expectedExceptionType.Name,
+                    actualException.GetType().Name),
+                actualException);
+        }
+
+        private static class Recorder
+        {
+            public static Exception Exception(Action code)
+            {
+                try
+                {
+                    code();
+                    return null;
+                }
+                catch (Exception e)
+                {
+                    return e;
+                }
+            }
+
+            public static TException Exception<TException>(Action code)
+                where TException : Exception
+            {
+                try
+                {
+                    code();
+                    return null;
+                }
+                catch (TException ex)
+                {
+                    return ex;
+                }
+                catch (Exception e)
+                {
+                    throw new AssertFailedException($"Expected to capture a {typeof(TException)} exception but got {e.GetType()}");
+                }
+            }
+
+            public static TException Exception<TException>(Func<object> code)
+                where TException : Exception
+            {
+                try
+                {
+                    code();
+                    return null;
+                }
+                catch (TException ex)
+                {
+                    return ex;
+                }
+                catch (Exception e)
+                {
+                    throw new AssertFailedException($"Expected to capture a {typeof(TException)} exception but got {e.GetType()}");
+                }
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/MsalCacheStorageTests.cs
+++ b/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/MsalCacheStorageTests.cs
@@ -116,6 +116,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
             var stringListener = new TraceStringListener();
             var actualLogger = new TraceSourceLogger(_logger);
             var cacheAccessor = Substitute.For<ICacheAccessor>();
+            cacheAccessor.CreateForPersistenceValidation().Returns(cacheAccessor);
             var exception = new InvalidOperationException("some error");
             var storage = new MsalCacheStorage(s_storageCreationProperties, cacheAccessor, actualLogger);
 
@@ -137,6 +138,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
             var stringListener = new TraceStringListener();
             var actualLogger = new TraceSourceLogger(_logger);
             var cacheAccessor = Substitute.For<ICacheAccessor>();
+            cacheAccessor.CreateForPersistenceValidation().Returns(cacheAccessor);
             var storage = new MsalCacheStorage(s_storageCreationProperties, cacheAccessor, actualLogger);
 
 
@@ -155,6 +157,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
             var stringListener = new TraceStringListener();
             var actualLogger = new TraceSourceLogger(_logger);
             var cacheAccessor = Substitute.For<ICacheAccessor>();
+            cacheAccessor.CreateForPersistenceValidation().Returns(cacheAccessor);
             var storage = new MsalCacheStorage(s_storageCreationProperties, cacheAccessor, actualLogger);
             cacheAccessor.Read().Returns(Encoding.UTF8.GetBytes("other_dummy_data"));
 
@@ -175,6 +178,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
             var stringListener = new TraceStringListener();
             var actualLogger = new TraceSourceLogger(_logger);
             var cacheAccessor = Substitute.For<ICacheAccessor>();
+            cacheAccessor.CreateForPersistenceValidation().Returns(cacheAccessor);
             var storage = new MsalCacheStorage(s_storageCreationProperties, cacheAccessor, actualLogger);
             cacheAccessor.Read().Returns(dummyData);
 
@@ -183,6 +187,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
 
             // Assert
             Received.InOrder(() => {
+                cacheAccessor.CreateForPersistenceValidation();
                 cacheAccessor.Write(Arg.Any<byte[]>());
                 cacheAccessor.Read();
                 cacheAccessor.Clear();

--- a/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/MsalCacheStorageTests.cs
+++ b/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/MsalCacheStorageTests.cs
@@ -5,10 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
+using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -108,6 +107,86 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
             Assert.IsTrue(stringListener.CurrentLog.Contains("TestSource Error"));
             Assert.IsTrue(stringListener.CurrentLog.Contains("InvalidOperationException"));
             Assert.IsTrue(stringListener.CurrentLog.Contains("some error"));
+        }
+
+        [TestMethod]
+        public void VerifyPersistenceThrowsInnerExceptions()
+        {
+            // Arrange
+            var stringListener = new TraceStringListener();
+            var actualLogger = new TraceSourceLogger(_logger);
+            var cacheAccessor = Substitute.For<ICacheAccessor>();
+            var exception = new InvalidOperationException("some error");
+            var storage = new MsalCacheStorage(s_storageCreationProperties, cacheAccessor, actualLogger);
+
+            cacheAccessor.Read().Throws(exception);
+
+            // Act
+            var ex = AssertException.Throws<MsalCachePersistenceException>(
+                () => storage.VerifyPersistence());
+
+            // Assert
+            Assert.AreEqual(ex.InnerException, exception);
+        }
+
+
+        [TestMethod]
+        public void VerifyPersistenceThrowsIfDataReadIsEmpty()
+        {
+            // Arrange
+            var stringListener = new TraceStringListener();
+            var actualLogger = new TraceSourceLogger(_logger);
+            var cacheAccessor = Substitute.For<ICacheAccessor>();
+            var storage = new MsalCacheStorage(s_storageCreationProperties, cacheAccessor, actualLogger);
+
+
+            // Act
+            var ex = AssertException.Throws<MsalCachePersistenceException>(
+                () => storage.VerifyPersistence());
+
+            // Assert
+            Assert.IsNull(ex.InnerException); // no more details available
+        }
+
+        [TestMethod]
+        public void VerifyPersistenceThrowsIfDataReadIsDiffrentFromDataWritten()
+        {
+            // Arrange
+            var stringListener = new TraceStringListener();
+            var actualLogger = new TraceSourceLogger(_logger);
+            var cacheAccessor = Substitute.For<ICacheAccessor>();
+            var storage = new MsalCacheStorage(s_storageCreationProperties, cacheAccessor, actualLogger);
+            cacheAccessor.Read().Returns(Encoding.UTF8.GetBytes("other_dummy_data"));
+
+            // Act
+            var ex = AssertException.Throws<MsalCachePersistenceException>(
+                () => storage.VerifyPersistence());
+
+            // Assert
+            Assert.IsNull(ex.InnerException); // no more details available
+        }
+
+
+        [TestMethod]
+        public void VerifyPersistenceHappyPath()
+        {
+            // Arrange
+            byte[] dummyData = Encoding.UTF8.GetBytes(MsalCacheStorage.PersistenceValidationDummyData);
+            var stringListener = new TraceStringListener();
+            var actualLogger = new TraceSourceLogger(_logger);
+            var cacheAccessor = Substitute.For<ICacheAccessor>();
+            var storage = new MsalCacheStorage(s_storageCreationProperties, cacheAccessor, actualLogger);
+            cacheAccessor.Read().Returns(dummyData);
+
+            // Act
+            storage.VerifyPersistence();
+
+            // Assert
+            Received.InOrder(() => {
+                cacheAccessor.Write(Arg.Any<byte[]>());
+                cacheAccessor.Read();
+                cacheAccessor.Clear();
+            });
         }
 
         [TestMethod]


### PR DESCRIPTION
Add a `VerifyPersistence` convenience API that works by: 

- creates a cache accessor similar to the "main" one (not identical, otherwise it will overwrite the cache)
- writes, reads and clears some data
- throws an exception if the above fails

Tested on Windows (happy path only) and Linux - no libsecret and libsecret installed but not working (SSH). 

Testing remaining: Mac (happy path), Linux (happy path)