### PR TITLE
Fix file locking on Mono

### DIFF
--- a/src/Shared/SharedUtilities.cs
+++ b/src/Shared/SharedUtilities.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Identity.Client.Extensions.Web
         private static readonly string s_lNameEnvVar = Environment.GetEnvironmentVariable("LNAME");
         private static readonly string s_usernameEnvVar = Environment.GetEnvironmentVariable("USERNAME");
 
+        private static readonly Lazy<bool> s_isMono = new Lazy<bool>(() => Type.GetType("Mono.Runtime") != null);
+
         /// <summary>
         ///  Is this a windows platform
         /// </summary>
@@ -64,6 +66,15 @@ namespace Microsoft.Identity.Client.Extensions.Web
 #else
             return System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux);
 #endif
+        }
+
+        /// <summary>
+        ///  Is this running on mono
+        /// </summary>
+        /// <returns>A  value indicating if we are running on mono or not</returns>
+        internal static bool IsMonoPlatform()
+        {
+            return s_isMono.Value;
         }
 
         /// <summary>


### PR DESCRIPTION
Mono behaves differently to dotnet and .NET on Windows with file
locks. Creating a FileStream with FileShare.None will not lock the
file when running on Mono. For this to work on Mono FileStream.Lock
has to be called.

Added Mono platform detection and the CrossPlatLock will call
FileStream.Lock on Mono. Also using FileOptions.DeleteOnClose is
a problem on Mono since the file can be deleted from another process
without a lock so the lock file is not deleted when on Mono.