### PR TITLE
Update to MSAL 4.25.0 and fix bug expiring tokens in test app.

### DIFF
--- a/sample/ManualTestApp/ManualTestApp.csproj
+++ b/sample/ManualTestApp/ManualTestApp.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.24.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.25.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/sample/ManualTestApp/Program.cs
+++ b/sample/ManualTestApp/Program.cs
@@ -77,7 +77,7 @@ namespace ManualTestApp
 
                         result = await pca.AcquireTokenWithDeviceCode(Config.Scopes, (dcr) =>
                         {
-                            Console.BackgroundColor = ConsoleColor.Cyan;
+                            Console.BackgroundColor = ConsoleColor.DarkCyan;
                             Console.WriteLine(dcr.Message);
                             Console.ResetColor();
 
@@ -180,10 +180,10 @@ namespace ManualTestApp
 
                         var ctor = typeof(TokenCacheNotificationArgs).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance).Single();
 
-                        var argz = ctor.Invoke(new object[] { pca.UserTokenCache, Config.ClientId, null, true, false });
+                        var notificationArgs = ctor.Invoke(new object[] { pca.UserTokenCache, Config.ClientId, null, true, false, true, null });
                         var task = pca.UserTokenCache.GetType().GetRuntimeMethods()
                             .Single(m => m.Name == "Microsoft.Identity.Client.ITokenCacheInternal.OnAfterAccessAsync")
-                            .Invoke(pca.UserTokenCache, new[] { argz });
+                            .Invoke(pca.UserTokenCache, new[] { notificationArgs });
 
                         await (task as Task).ConfigureAwait(false);
                         break;

--- a/src/Microsoft.Identity.Client.Extensions.Msal/Microsoft.Identity.Client.Extensions.Msal.csproj
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/Microsoft.Identity.Client.Extensions.Msal.csproj
@@ -31,7 +31,7 @@
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.24.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.25.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetDesktop)'">

--- a/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/Microsoft.Identity.Client.Extensions.Msal.UnitTests.csproj
+++ b/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/Microsoft.Identity.Client.Extensions.Msal.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.24.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.25.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />


### PR DESCRIPTION
Ran unit tests and test app in Windows.