### PR TITLE
Fix for #98 - cache cannot be used with ADFS

### DIFF
--- a/sample/ManualTestApp/ExampleUsage.cs
+++ b/sample/ManualTestApp/ExampleUsage.cs
@@ -80,8 +80,7 @@ namespace ManualTestApp
             {
                 return new StorageCreationPropertiesBuilder(
                                    Config.CacheFileName,
-                                   Config.CacheDir,
-                                   Config.ClientId)
+                                   Config.CacheDir)
                                .WithLinuxKeyring(
                                    Config.LinuxKeyRingSchema,
                                    Config.LinuxKeyRingCollection,
@@ -96,8 +95,7 @@ namespace ManualTestApp
 
             return new StorageCreationPropertiesBuilder(
                                      Config.CacheFileName,
-                                     Config.CacheDir,
-                                     Config.ClientId)
+                                     Config.CacheDir)
                                  .WithLinuxUnprotectedFile()
                                  .WithMacKeyChain(
                                      Config.KeyChainServiceName,

--- a/sample/ManualTestApp/ManualTestApp.csproj
+++ b/sample/ManualTestApp/ManualTestApp.csproj
@@ -4,8 +4,8 @@
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
 
-    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">netcoreapp3.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOsPlatform('Windows'))">netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOsPlatform('Windows'))">netcoreapp3.1</TargetFrameworks>
 
   </PropertyGroup>
 

--- a/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheHelper.cs
+++ b/src/Microsoft.Identity.Client.Extensions.Msal/MsalCacheHelper.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal
         /// <summary>
         /// Watches a filesystem location in order to fire events when the cache on disk is changed. Internal for testing.
         /// </summary>
-        internal readonly FileSystemWatcher _cacheWatcher;
+        private readonly FileSystemWatcher _cacheWatcher;
 
         private EventHandler<CacheChangedEventArgs> _cacheChangedEventHandler;
         /// <summary>

--- a/src/Shared/EnvUtils.cs
+++ b/src/Shared/EnvUtils.cs
@@ -14,9 +14,11 @@ namespace Microsoft.Identity.Client.Extensions.Msal
     internal static class EnvUtils
     {
         internal const string TraceLevelEnvVarName = "IDENTITYEXTENSIONTRACELEVEL";
+        private const string DefaultTraceSource = "Microsoft.Identity.Client.Extensions.TraceSource";
 
         internal static TraceSource GetNewTraceSource(string sourceName)
         {
+            sourceName = sourceName ?? DefaultTraceSource;
 #if DEBUG
             var level = SourceLevels.Verbose;
 #else
@@ -29,7 +31,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal
                 level = result;
             }
 
-            return new TraceSource("Microsoft.Identity.Client.Extensions.TraceSource", level);
+            return new TraceSource(sourceName, level);
         }
     }
 }

--- a/src/Shared/StorageCreationProperties.cs
+++ b/src/Shared/StorageCreationProperties.cs
@@ -14,10 +14,10 @@ namespace Microsoft.Identity.Client.Extensions.Msal
 namespace Microsoft.Identity.Client.Extensions.Web
 #endif
 {
-/// <summary>
-/// An immutable class containing information required to instantiate storage objects for MSAL caches in various platforms.
-/// </summary>
-public class StorageCreationProperties
+    /// <summary>
+    /// An immutable class containing information required to instantiate storage objects for MSAL caches in various platforms.
+    /// </summary>
+    public class StorageCreationProperties
     {
         /// <summary>
         /// This constructor is intentionally internal. To get one of these objects use <see cref="StorageCreationPropertiesBuilder.Build"/>.
@@ -33,9 +33,10 @@ public class StorageCreationProperties
             string keyringSecretLabel,
             KeyValuePair<string, string> keyringAttribute1,
             KeyValuePair<string, string> keyringAttribute2,
-            string clientId,
             int lockRetryDelay,
-            int lockRetryCount)
+            int lockRetryCount,
+            string clientId,
+            string authority)
         {
             CacheFileName = cacheFileName;
             CacheDirectory = cacheDirectory;
@@ -53,6 +54,7 @@ public class StorageCreationProperties
             KeyringAttribute2 = keyringAttribute2;
 
             ClientId = clientId;
+            Authority = authority;
             LockRetryDelay = lockRetryDelay;
             LockRetryCount = lockRetryCount;
         }
@@ -123,8 +125,24 @@ public class StorageCreationProperties
         public readonly int LockRetryCount;
 
         /// <summary>
-        /// The client id
+        /// The client id.
         /// </summary>
+        /// <remarks> Only required for the MsalCacheHelper.CacheChanged event</remarks>
         public string ClientId { get; }
+
+        /// <summary>
+        /// The authority
+        /// </summary>
+        /// <remarks> Only required for the MsalCacheHelper.CacheChanged event</remarks>
+        public string Authority { get; }
+
+        internal bool IsCacheEventConfigured
+        {
+            get
+            {
+                return !string.IsNullOrEmpty(ClientId) &&
+                   !string.IsNullOrEmpty(Authority);
+            }
+        }
     }
 }

--- a/src/Shared/StorageCreationPropertiesBuilder.cs
+++ b/src/Shared/StorageCreationPropertiesBuilder.cs
@@ -12,14 +12,15 @@ namespace Microsoft.Identity.Client.Extensions.Msal
 namespace Microsoft.Identity.Client.Extensions.Web
 #endif
 {
-/// <summary>
-/// An incremental builder for <see cref="StorageCreationProperties"/> objects.
-/// </summary>
-public class StorageCreationPropertiesBuilder
+    /// <summary>
+    /// An incremental builder for <see cref="StorageCreationProperties"/> objects.
+    /// </summary>
+    public class StorageCreationPropertiesBuilder
     {
         private readonly string _cacheFileName;
         private readonly string _cacheDirectory;
-        private readonly string _clientId;
+        private string _clientId;
+        private string _authority;
         private string _macKeyChainServiceName;
         private string _macKeyChainAccountName;
         private string _keyringSchemaName;
@@ -37,11 +38,25 @@ public class StorageCreationPropertiesBuilder
         /// <param name="cacheFileName">The name of the cache file to use when creating or opening storage.</param>
         /// <param name="cacheDirectory">The name of the directory containing the cache file.</param>
         /// <param name="clientId">The client id for the calling application</param>
+        [Obsolete("Use StorageCreationPropertiesBuilder(string, string) instead. " +
+            "If you need to consume the CacheChanged event then also use WithCacheChangedEvent(string, string)", false)]
         public StorageCreationPropertiesBuilder(string cacheFileName, string cacheDirectory, string clientId)
         {
             _cacheFileName = cacheFileName;
             _cacheDirectory = cacheDirectory;
             _clientId = clientId;
+            _authority = "https://login.microsoftonline.com/common"; 
+        }
+
+        /// <summary>
+        /// Constructs a new instance of this builder associated with the given cache file.
+        /// </summary>
+        /// <param name="cacheFileName">The name of the cache file to use when creating or opening storage.</param>
+        /// <param name="cacheDirectory">The name of the directory containing the cache file.</param>
+        public StorageCreationPropertiesBuilder(string cacheFileName, string cacheDirectory)
+        {
+            _cacheFileName = cacheFileName;
+            _cacheDirectory = cacheDirectory;
         }
 
         /// <summary>
@@ -61,9 +76,10 @@ public class StorageCreationPropertiesBuilder
                 _keyringSecretLabel,
                 _keyringAttribute1,
                 _keyringAttribute2,
-                _clientId,
                 _lockRetryDelay,
-                _lockRetryCount);
+                _lockRetryCount,
+                _clientId,
+                _authority);
         }
 
         /// <summary>
@@ -80,6 +96,21 @@ public class StorageCreationPropertiesBuilder
         }
 
         /// <summary>
+        /// Enables the use of the MsalCacheHelper.CacheChanged event. 
+        /// </summary>
+        /// <param name="clientId">The client id for the calling application</param>
+        /// <param name="authority">Authority used by the calling application</param>
+        /// <returns>The augmented builder</returns>        
+        public StorageCreationPropertiesBuilder WithCacheChangedEvent(
+            string clientId,
+            string authority = "https://login.microsoftonline.com/common")
+        {
+            _clientId = clientId;
+            _authority = authority;
+            return this;
+        }
+
+        /// <summary>
         /// Augments this builder with a custom retry ammount and delay between retries in the cases where a lock is used.
         /// </summary>
         /// <param name="lockRetryDelay">Delay between retries in ms, must be 1 or more</param>
@@ -87,7 +118,7 @@ public class StorageCreationPropertiesBuilder
         /// <returns>The augmented builder</returns>
         public StorageCreationPropertiesBuilder CustomizeLockRetry(int lockRetryDelay, int lockRetryCount)
         {
-            if(lockRetryDelay < 1)
+            if (lockRetryDelay < 1)
             {
                 throw new ArgumentOutOfRangeException(nameof(lockRetryDelay));
             }

--- a/src/Shared/StorageCreationPropertiesBuilder.cs
+++ b/src/Shared/StorageCreationPropertiesBuilder.cs
@@ -96,10 +96,12 @@ namespace Microsoft.Identity.Client.Extensions.Web
         }
 
         /// <summary>
-        /// Enables the use of the MsalCacheHelper.CacheChanged event. 
+        /// Enables the use of the MsalCacheHelper.CacheChanged event, which notifies about
+        /// accounts added and removed. These accounts are scoped to the client_id and authority
+        /// specified here.
         /// </summary>
-        /// <param name="clientId">The client id for the calling application</param>
-        /// <param name="authority">Authority used by the calling application</param>
+        /// <param name="clientId">The client id for which you wish to receive notifications</param>
+        /// <param name="authority">The authority for which you wish to receive notifications</param>
         /// <returns>The augmented builder</returns>        
         public StorageCreationPropertiesBuilder WithCacheChangedEvent(
             string clientId,

--- a/tests/Microsoft.Identity.Client.Extensions.Adal.UnitTests/AdalCacheStorageTests.cs
+++ b/tests/Microsoft.Identity.Client.Extensions.Adal.UnitTests/AdalCacheStorageTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Identity.Client.Extensions.Adal.UnitTests
         [ClassInitialize]
         public static void ClassInitialize(TestContext _)
         {
-            var builder = new StorageCreationPropertiesBuilder(Path.GetFileName(CacheFilePath), Path.GetDirectoryName(CacheFilePath), "ClientIDGoesHere");
+            var builder = new StorageCreationPropertiesBuilder(Path.GetFileName(CacheFilePath), Path.GetDirectoryName(CacheFilePath));
             builder = builder.WithMacKeyChain(serviceName: "Microsoft.Developer.IdentityService", accountName: "ADALCache");
             builder = builder.WithLinuxKeyring(
                 schemaName: "IdentityServiceAdalCache.cache",

--- a/tests/Microsoft.Identity.Client.Extensions.Adal.UnitTests/AdalCacheTests.cs
+++ b/tests/Microsoft.Identity.Client.Extensions.Adal.UnitTests/AdalCacheTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Identity.Client.Extensions.Adal.UnitTests
         [ClassInitialize]
         public static void ClassInitialize(TestContext _)
         {
-            var builder = new StorageCreationPropertiesBuilder(Path.GetFileName(CacheFilePath), Path.GetDirectoryName(CacheFilePath), "ClientIDGoesHere");
+            var builder = new StorageCreationPropertiesBuilder(Path.GetFileName(CacheFilePath), Path.GetDirectoryName(CacheFilePath));
             builder = builder.WithMacKeyChain(serviceName: "Microsoft.Developer.IdentityService", accountName: "MSALCache");
             builder = builder.WithLinuxKeyring(
                 schemaName: "adal.cache",

--- a/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/IntegrationTests.cs
+++ b/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/IntegrationTests.cs
@@ -33,13 +33,12 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
         {
             var storageBuilder = new StorageCreationPropertiesBuilder(
                 Path.GetFileName(CacheFilePath),
-                Path.GetDirectoryName(CacheFilePath),
-                ClientId);
+                Path.GetDirectoryName(CacheFilePath));
             storageBuilder = storageBuilder.WithMacKeyChain(
                 serviceName: "Microsoft.Developer.IdentityService.Test",
                 accountName: "MSALCacheTest");
 
-           // unit tests run on Linux boxes without LibSecret 
+            // unit tests run on Linux boxes without LibSecret 
             storageBuilder.WithLinuxUnprotectedFile();
 
             // 1. Use MSAL to create an instance of the Public Client Application
@@ -60,9 +59,9 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
         public void ImportExport()
         {
             var storageBuilder = new StorageCreationPropertiesBuilder(
-          Path.GetFileName(CacheFilePath),
-          Path.GetDirectoryName(CacheFilePath),
-          ClientId);
+                Path.GetFileName(CacheFilePath),
+                Path.GetDirectoryName(CacheFilePath));
+
             storageBuilder = storageBuilder.WithMacKeyChain(
                 serviceName: "Microsoft.Developer.IdentityService.Test",
                 accountName: "MSALCacheTest");

--- a/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/Microsoft.Identity.Client.Extensions.Msal.UnitTests.csproj
+++ b/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/Microsoft.Identity.Client.Extensions.Msal.UnitTests.csproj
@@ -32,6 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Resources\token_cache_adfs.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\token_cache_one_acc_seed.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/MsalCacheStorageIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/MsalCacheStorageIntegrationTests.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
         [ClassInitialize]
         public static void ClassInitialize(TestContext _)
         {
-            var builder = new StorageCreationPropertiesBuilder(Path.GetFileName(CacheFilePath), Path.GetDirectoryName(CacheFilePath), "ClientIDGoesHere");
+            var builder = new StorageCreationPropertiesBuilder(
+                Path.GetFileName(CacheFilePath),
+                Path.GetDirectoryName(CacheFilePath));
             builder = builder.WithMacKeyChain(serviceName: "Microsoft.Developer.IdentityService", accountName: "MSALCache");
 
             // Tests run on machines without Libsecret
@@ -83,8 +85,7 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
         {
             var storageWithKeyRing = new StorageCreationPropertiesBuilder(
                     Path.GetFileName(CacheFilePath),
-                    Path.GetDirectoryName(CacheFilePath),
-                    "ClientIDGoesHere")
+                    Path.GetDirectoryName(CacheFilePath))
                 .WithMacKeyChain(serviceName: "Microsoft.Developer.IdentityService", accountName: "MSALCache")
                 .WithLinuxKeyring(
                     schemaName: "msal.cache",

--- a/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/MsalCacheStorageTests.cs
+++ b/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/MsalCacheStorageTests.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Identity.Client.Extensions.Msal.UnitTests
         [ClassInitialize]
         public static void ClassInitialize(TestContext _)
         {
-            var builder = new StorageCreationPropertiesBuilder(Path.GetFileName(CacheFilePath), Path.GetDirectoryName(CacheFilePath), "ClientIDGoesHere");
+            var builder = new StorageCreationPropertiesBuilder(
+                Path.GetFileName(CacheFilePath),
+                Path.GetDirectoryName(CacheFilePath));
             builder = builder.WithMacKeyChain(serviceName: "Microsoft.Developer.IdentityService", accountName: "MSALCache");
             builder = builder.WithLinuxKeyring(
                 schemaName: "msal.cache",

--- a/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/Resources/token_cache_adfs.json
+++ b/tests/Microsoft.Identity.Client.Extensions.Msal.UnitTests/Resources/token_cache_adfs.json
@@ -1,0 +1,48 @@
+﻿{
+  "AccessToken": {
+    "unzyjm1nugflhp1l338bxhryyhbtcyowx1p+f2fcsiq=-fs.msidlab8.com-accesstoken-publicclientid--openid": {
+      "home_account_id": "unZYjm1NugFLhP1l338bxhRYyHbtCYOWX1P+F2fCsiQ=",
+      "environment": "fs.msidlab8.com",
+      "client_id": "PublicClientId",
+      "secret": "secret",
+      "credential_type": "AccessToken",
+      "target": "openid",
+      "cached_at": "1613060010",
+      "expires_on": "1613063610",
+      "extended_expires_on": "-62135596800",
+      "ext_expires_on": "-62135596800"
+    }
+  },
+  "RefreshToken": {
+    "unzyjm1nugflhp1l338bxhryyhbtcyowx1p+f2fcsiq=-fs.msidlab8.com-refreshtoken-publicclientid--": {
+      "home_account_id": "unZYjm1NugFLhP1l338bxhRYyHbtCYOWX1P+F2fCsiQ=",
+      "environment": "fs.msidlab8.com",
+      "client_id": "PublicClientId",
+      "secret": "secret",
+      "credential_type": "RefreshToken"
+    }
+  },
+  "IdToken": {
+    "unzyjm1nugflhp1l338bxhryyhbtcyowx1p+f2fcsiq=-fs.msidlab8.com-idtoken-publicclientid--": {
+      "home_account_id": "unZYjm1NugFLhP1l338bxhRYyHbtCYOWX1P+F2fCsiQ=",
+      "environment": "fs.msidlab8.com",
+      "client_id": "PublicClientId",
+      "secret": "s",
+      "credential_type": "IdToken"
+    }
+  },
+  "Account": {
+    "unZYjm1NugFLhP1l338bxhRYyHbtCYOWX1P+F2fCsiQ=-fs.msidlab8.com-": {
+      "home_account_id": "unZYjm1NugFLhP1l338bxhRYyHbtCYOWX1P+F2fCsiQ=",
+      "environment": "fs.msidlab8.com",
+      "username": "fidlab@msidlab8.com",
+      "authority_type": "MSSTS"
+    }
+  },
+  "AppMetadata": {
+    "appmetadata-fs.msidlab8.com-publicclientid": {
+      "environment": "fs.msidlab8.com",
+      "client_id": "PublicClientId"
+    }
+  }
+}


### PR DESCRIPTION
Before this fix, developers had to configure client_id. 

This design does not take into account the following, which this PR fixes:

- it's not clear that `CacheChanged` event is only relevant for the given client_id
- since authority is not configured, the default authority is implied (i.e. `l.m.o/common`). This is the root cause of bug #89 
- developers cannot use 1 instance of the CacheExtension for multiple client_ids (since a client_id is needed to construct it)

Fixes #98 #123 #121 #102  (yay!)