### PR TITLE
Add explicit task to use .NET version in build pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,11 @@ steps:
   inputs:
     version: 3.1.x
 
+- task: UseDotNet@2
+  displayName: 'Use .NET SDK 6.x'
+  inputs:
+    version: 6.x
+
 - task: DotNetCoreCLI@2
   displayName: Restore
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,10 +20,19 @@ pool:
   vmImage: $(imageName)
 
 steps:
+
+- task: UseDotNet@2
+  displayName: 'Use .NET SDK 6.x'
+  inputs:
+    version: 6.x
+
 - task: DotNetCoreCLI@2
+  displayName: Restore
   inputs:
     command: 'restore'  
+
 - task: DotNetCoreCLI@2
+  displayName: Build
   inputs:
     command: 'build'
 
@@ -33,4 +42,3 @@ steps:
     command: test
     projects: 'tests/**/*UnitTests*.csproj'
     arguments: '--no-build --no-restore --collect "Code coverage"'
-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,9 +22,9 @@ pool:
 steps:
 
 - task: UseDotNet@2
-  displayName: 'Use .NET SDK 6.x'
+  displayName: 'Use .NET Core SDK 3.1.x'
   inputs:
-    version: 6.x
+    version: 3.1.x
 
 - task: DotNetCoreCLI@2
   displayName: Restore

--- a/release_build.yaml
+++ b/release_build.yaml
@@ -9,15 +9,15 @@ steps:
 
 # required for the signing task, but should not be used for the entire build
 - task: UseDotNet@2
-  displayName: 'Use .Net Core sdk 2.1.x'
+  displayName: 'Use .NET Core SDK 2.1.x'
   inputs:
     version: 2.1.x
 
 # Use latest SDK for build
 - task: UseDotNet@2
-  displayName: 'Use .Net Core sdk 5.x'
+  displayName: 'Use .NET SDK 6.x'
   inputs:
-    version: 5.x
+    version: 6.x
 
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
   displayName: 'Run PoliCheck'
@@ -111,7 +111,7 @@ steps:
     BinSkim: true
 
 - task: DotNetCoreCLI@2
-  displayName: 'dotnet pack'
+  displayName: Pack projects
   inputs:
     command: pack
     packagesToPack: 'src/**/*.csproj'


### PR DESCRIPTION
The images don't seem to have these older frameworks installed by default; have to install manually.